### PR TITLE
Fixed Issue #172 - Readline-like history for Web Almond

### DIFF
--- a/public/javascripts/conversation.js
+++ b/public/javascripts/conversation.js
@@ -333,8 +333,8 @@ $(function() {
         event.preventDefault();
     });
 
-    $('#input-form').on('keydown', function(event) { // up button is pressed (For issue #172)
-      if (event.keyCode == 38) {  //Up
+    $('#input-form').on('keydown', function(event) { // button is pressed
+      if (event.keyCode === 38) {  // Up
         // removes last item from array pastCommandsUp, displays it as currCommand, adds current input text to pastCommandsDown
         currCommand = pastCommandsUp.pop();
         if ($('#input').val() !== "") {
@@ -342,10 +342,8 @@ $(function() {
         }
         $('#input').val(currCommand);
       }
-    });
 
-    $('#input-form').on('keydown', function(event) { // down button is pressed (For issue #172)
-      if (event.keyCode == 40) {  //Down
+      if (event.keyCode === 40) {  // Down
         // removes last item from array pastCommandsDown, displays it as currCommand, adds current input text to pastCommandsUp
         currCommand = pastCommandsDown.pop();
         if ($('#input').val() !== "") {

--- a/public/javascripts/conversation.js
+++ b/public/javascripts/conversation.js
@@ -5,6 +5,11 @@ $(function() {
 
     var ws;
     var open = false;
+
+    var pastCommandsUp = []; // array accessed by pressing up arrow
+    var pastCommandsDown = []; // array accessed by pressing down arrow
+    var currCommand = ""; // current command between pastCommandsUp and pastCommandsDown
+
     function updateFeedback(thinking) {
         if (!ws || !open) {
             $('#input-form-group').addClass('has-warning');
@@ -304,6 +309,15 @@ $(function() {
 
     $('#input-form').submit(function(event) {
         var text = $('#input').val();
+        if (currCommand !== "") {
+          pastCommandsUp.push(currCommand);
+        }
+        if (pastCommandsDown.length !== 0) {
+          pastCommandsUp = pastCommandsUp.concat(pastCommandsDown);
+          pastCommandsDown = [];
+        }
+        pastCommandsUp.push(text);
+
         $('#input').val('');
 
         handleCommand(text);
@@ -317,5 +331,27 @@ $(function() {
         $(this).hide();
         $('#conversation').collapse('show');
         event.preventDefault();
+    });
+
+    $('#input-form').on('keydown', function(event) { // up button is pressed (For issue #172)
+      if (event.keyCode == 38) {  //Up
+        // removes last item from array pastCommandsUp, displays it as currCommand, adds current input text to pastCommandsDown
+        currCommand = pastCommandsUp.pop();
+        if ($('#input').val() !== "") {
+          pastCommandsDown.push($('#input').val());
+        }
+        $('#input').val(currCommand);
+      }
+    });
+
+    $('#input-form').on('keydown', function(event) { // down button is pressed (For issue #172)
+      if (event.keyCode == 40) {  //Down
+        // removes last item from array pastCommandsDown, displays it as currCommand, adds current input text to pastCommandsUp
+        currCommand = pastCommandsDown.pop();
+        if ($('#input').val() !== "") {
+          pastCommandsUp.push($('#input').val());
+        }
+        $('#input').val(currCommand);
+      }
     });
 });


### PR DESCRIPTION
This is the fix for Issue #172. It creates a readline-like history for web almond which allows the user to press the up and down keys to toggle through previous commands.

It uses two arrays and a new instance variable to keep track of these commands.