### PR TITLE
Add Thingpedia API to lookup locations

### DIFF
--- a/config.js
+++ b/config.js
@@ -392,7 +392,7 @@ module.exports.DISCOURSE_SSO_SECRET = null;
 module.exports.DISCOURSE_SSO_REDIRECT = null;
 
 /**
-   What natural languages are enabled, as BCP47 locale tags.
+  What natural languages are enabled, as BCP47 locale tags.
 
   Defaults to American English only
 
@@ -400,3 +400,12 @@ module.exports.DISCOURSE_SSO_REDIRECT = null;
   to start.
 */
 module.exports.SUPPORTED_LANGUAGES = ['en-US'];
+
+/**
+  MapQuest API key.
+
+  This is key is used to provide the location querying API. If unset, it will
+  fallback to the public Nominatim API, which has a low API quota.
+*/
+module.exports.MAPQUEST_KEY = null;
+ 

--- a/doc/almond-config-file-reference.md
+++ b/doc/almond-config-file-reference.md
@@ -390,7 +390,7 @@ Set this to the URL of your Discourse installation. This should be the origin
 Default value: `null`
 
 ## SUPPORTED_LANGUAGES
- What natural languages are enabled, as BCP47 locale tags.
+What natural languages are enabled, as BCP47 locale tags.
 
 Defaults to American English only
 
@@ -398,4 +398,12 @@ Note that this must contain at least one language, or the server will fail
 to start.
 
 Default value: `['en-US']`
+
+## MAPQUEST_KEY
+MapQuest API key.
+
+This is key is used to provide the location querying API. If unset, it will
+fallback to the public Nominatim API, which has a low API quota.
+
+Default value: `null`
 

--- a/routes/thingpedia_api.js
+++ b/routes/thingpedia_api.js
@@ -1731,6 +1731,55 @@ v3.get('/entities/icon', (req, res, next) => {
 });
 
 /**
+ * @api {get} /v3/locations/lookup Lookup Location By Name
+ * @apiName LookupLocation
+ * @apiGroup Entities
+ * @apiVersion 0.3.0
+ *
+ * @apiDescription Lookup a location given its name (also known as "geocoding").
+ *   Use this endpoint to perform Entity Linking after identifying an span corresponding to a locationn.
+ *
+ * @apiParam {String} q Query String
+ * @apiParam {String} [locale=en-US] Locale in which metadata should be returned
+ *
+ * @apiSuccess {String} result Whether the API call was successful; always the value `ok`
+ * @apiSuccess {Object[]} data List of candidate locations values; the list is sorted by importance
+ * @apiSuccess {Number{-90,90}} data.lat Latitude
+ * @apiSuccess {Number{-180,180}} data.lon Longitude
+ * @apiSuccess {String} data.display User-visible name of this location
+ * @apiSuccess {Number} data.canonical Preprocessed (tokenized and lower-cased) version of the user-visible name
+ *
+ * @apiSuccessExample {json} Example Response:
+ *  {
+ *    "result": "ok",
+ *    "data": [
+ *      {
+ *        "type": "tt:stock_id",
+ *        "value": "wmt",
+ *        "canonical": "walmart inc.",
+ *        "name": "Walmart Inc."
+ *      }
+ *    ]
+ *  }
+ *
+ */
+v3.get('/locations/lookup', (req, res, next) => {
+    const searchKey = req.query.q;
+
+    if (!searchKey) {
+        res.status(400).json({ error: 'missing query' });
+        return;
+    }
+
+    var client = new ThingpediaClient(req.query.developer_key, req.query.locale);
+
+    client.lookupLocation(searchKey).then((data) => {
+        res.cacheFor(300000);
+        res.status(200).json({ result: 'ok', data });
+    }).catch(next);
+});
+
+/**
  * @api {get} /v3/snapshot/:snapshot Get Thingpedia Snapshot
  * @apiName GetSnapshot
  * @apiGroup Schemas

--- a/tests/test_thingpedia_api_v3.js
+++ b/tests/test_thingpedia_api_v3.js
@@ -1643,7 +1643,32 @@ async function testLookupEntity() {
         },
         data: []
     });
+}
 
+async function testLookupLocation() {
+    const result = await request('/locations/lookup?q=seattle');
+
+    assert.strictEqual(result.result, 'ok');
+    assert(Array.isArray(result.data));
+
+    let found = false;
+    for (let loc of result.data) {
+        assert.strictEqual(typeof loc.latitude, 'number');
+        assert.strictEqual(typeof loc.longitude, 'number');
+        assert.strictEqual(typeof loc.display, 'string');
+        assert.strictEqual(typeof loc.canonical, 'string');
+        assert.strictEqual(typeof loc.rank, 'number');
+        assert.strictEqual(typeof loc.importance, 'number');
+
+        if (loc.display === 'Seattle, King County, Washington, USA') {
+            assert(Math.abs(loc.latitude - 47.6038321) < 1e-6);
+            assert(Math.abs(loc.longitude - -122.3300624) < 1e-6);
+            assert.strictEqual(loc.canonical, 'seattle king county washington usa');
+            assert.strictEqual(loc.rank, 16);
+            found = true;
+        }
+    }
+    assert(found);
 }
 
 async function getAccessToken(session) {
@@ -1822,6 +1847,7 @@ async function main() {
     await testGetEntityList();
     await testGetEntityValues();
     await testLookupEntity();
+    await testLookupLocation();
     await testEntityUpload();
     await testStringUpload();
 }

--- a/util/location-linking.js
+++ b/util/location-linking.js
@@ -1,0 +1,44 @@
+// -*- mode: js; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of Almond
+//
+// Copyright 2019 The Board of Trustees of the Leland Stanford Junior University
+//
+// Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
+//
+// See COPYING for details
+"use strict";
+
+const Tp = require('thingpedia');
+const qs = require('qs');
+
+const Config = require('../config');
+
+const URL = 'http://open.mapquestapi.com/nominatim/v1/search.php'; // key=%s&format=jsonv2&accept-language=%s&limit=5&q=%s";
+const FREE_URL = 'http://nominatim.openstreetmap.org/search/?'; //?format=jsonv2&accept-language=%s&limit=5&q=%s
+
+module.exports = async function resolveLocation(locale, searchKey) {
+    let url;
+    if (Config.MAPQUEST_KEY)
+        url = URL + '?key=' + Config.MAPQUEST_KEY + '&';
+    else
+        url = FREE_URL;
+
+    const parsed = JSON.parse(await Tp.Helpers.Http.get(url + qs.stringify({
+        format: 'jsonv2',
+        'accept-language': locale,
+        limit: 5,
+        q: searchKey
+    })));
+
+    return parsed.map((result) => {
+        return {
+            latitude: Number(result.lat),
+            longitude: Number(result.lon),
+            display: result.display_name,
+            canonical: result.display_name.toLowerCase().replace(/[,\s]+/g, ' '),
+            rank: result.place_rank,
+            importance: result.importance,
+        };
+    });
+};

--- a/util/thingpedia-client.js
+++ b/util/thingpedia-client.js
@@ -30,6 +30,7 @@ const FactoryUtils = require('./device_factories');
 const I18n = require('./i18n');
 const codeStorage = require('./code_storage');
 const { NotFoundError, ForbiddenError, BadRequestError } = require('./errors');
+const resolveLocation = require('./location-linking');
 
 class ThingpediaDiscoveryDatabase {
     getByDiscoveryService(discoveryType, service) {
@@ -398,6 +399,10 @@ module.exports = class ThingpediaClientCloud extends TpClient.BaseClient {
         });
     }
 
+    lookupLocation(searchTerm) {
+        return resolveLocation(this.locale, searchTerm);
+    }
+
     getAllExamples(accept = 'application/x-thingtalk') {
         return this._withClient(async (dbClient) => {
             const rows = await exampleModel.getBaseByLanguage(dbClient, await this._getOrgId(dbClient), this.language);
@@ -442,4 +447,4 @@ module.exports.prototype.$rpcMethods = ['getAppCode', 'getApps',
                                         'getDeviceSearch',
                                         'getKindByDiscovery',
                                         'getExamplesByKinds', 'getExamplesByKey',
-                                        'clickExample', 'lookupEntity'];
+                                        'clickExample', 'lookupEntity', 'lookupLocation'];


### PR DESCRIPTION
This way we can move location entity linking to the client
without hardcoding either Nominatim or MapQuest

This PR is against the stable branch because we need to backport the API so the dialog agent can make use of it