### PR TITLE
Add location compatibility code

### DIFF
--- a/tests/unit/index.js
+++ b/tests/unit/index.js
@@ -23,4 +23,5 @@ seq([
     ('./test_trie'),
     ('./test_edit_distance'),
     ('./test_exact_matcher'),
+    ('./test_nlp_compat'),
 ]);

--- a/tests/unit/test_nlp_compat.js
+++ b/tests/unit/test_nlp_compat.js
@@ -1,0 +1,61 @@
+// -*- mode: js; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of Almond Cloud
+//
+// Copyright 2019 The Board of Trustees of the Leland Stanford Junior University
+//
+// Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
+//
+// See COPYING for details
+"use strict";
+
+const assert = require('assert');
+
+const applyCompatibility = require('../../nlp/compat'); //(locale, results, entities, thingtalk_version)
+
+const TEST_CASES = [
+    [
+    '1.0.0', {},
+    '( monitor ( @com.washtingtonpost.get_article ) ) => ( @com.yandex.translate ) => notify',
+    '( monitor ( @com.washtingtonpost.get_article ) ) join ( @com.yandex.translate ) => notify',
+    ],
+
+    [
+    '1.7.3', {},
+    '( monitor ( @com.washtingtonpost.get_article ) ) => ( @com.yandex.translate ) => notify',
+    '( monitor ( @com.washtingtonpost.get_article ) ) => ( @com.yandex.translate ) => notify',
+    ],
+
+    [
+    '1.7.2', {},
+    'now => @org.thingpedia.weather.current param:location:Location = location: " seattle " => notify',
+    'now => @org.thingpedia.weather.current param:location:Location = LOCATION_0 => notify',
+    ],
+
+    [
+    '1.7.3', {},
+    'now => @org.thingpedia.weather.current param:location:Location = location: " seattle " => notify',
+    'now => @org.thingpedia.weather.current param:location:Location = location: " seattle " => notify',
+    ],
+];
+
+async function test(i) {
+    console.log(`Test Case #${i+1}`);
+    const [version, entities, code, expected] = TEST_CASES[i];
+
+    const results = [{
+        code: code.split(' '),
+        score: 1
+    }];
+    await applyCompatibility('en-US', results, entities, version);
+
+    assert.strictEqual(results[0].code.join(' '), expected);
+}
+
+async function main() {
+    for (let i = 0; i < TEST_CASES[i]; i++)
+        await test(i);
+}
+module.exports = main;
+if (!module.parent)
+    main();


### PR DESCRIPTION
Compatibility is only applied based on ThingTalk version, not almond-dialog-agent version or other components. Hence, we need to make sure that if some Almond ships with ThingTalk 1.7.3, all other libraries in that install of Almond are ready for it.
Once that is done, we can take care of older versions of ThingTalk (and consequently Almond) by applying simple server-side compatibility code.

This PR is against the master branch, unlike #357, because we don't need to backport it to stable/production until we finally flip the switch in almond-tokenizer (which in turn will require a new version of Genie, so not happening soon)

Fixes #353