### PR TITLE
Add a database migration for the `credits` field of the organization …

### DIFF
--- a/model/migrations/3b78ae3-org_credits.sql
+++ b/model/migrations/3b78ae3-org_credits.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `organizations`
+    ADD `credits` int(11) NOT NULL DEFAULT 100;

--- a/model/schema.sql
+++ b/model/schema.sql
@@ -538,7 +538,7 @@ CREATE TABLE `organizations` (
   `comment` text COLLATE utf8_bin NOT NULL,
   `developer_key` char(64) COLLATE utf8_bin NOT NULL,
   `is_admin` tinyint(1) NOT NULL DEFAULT 0,
-  `credits` int(11) NOT NULL DEFAULT 0,
+  `credits` int(11) NOT NULL DEFAULT 100,
   `last_credit_update` datetime NOT NULL DEFAULT current_timestamp(),
   PRIMARY KEY (`id`),
   UNIQUE KEY `id_hash` (`id_hash`),


### PR DESCRIPTION
…table

And set the default to 100 credits per org, as per the
[design](https://wiki.almond.stanford.edu/LUInet/CreditSystem)