### PR TITLE
travis: stop caching embedding directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ cache:
   npm: true
   yarn: true
   pip: true
-  directories:
-  - tests/embeddings
 before_install:
 - ./travis/unlock-key.sh
 - mkdir cvc4/


### PR DESCRIPTION
Uploading to S3 at the end is way too slow, it's faster to download
from our servers every time