### PR TITLE
Add support for #[confirm] annotation

### DIFF
--- a/data/org.thingpedia.builtin.thingengine.builtin.yaml
+++ b/data/org.thingpedia.builtin.thingengine.builtin.yaml
@@ -57,31 +57,36 @@ class: |
     #_[canonical="log"]
     #_[confirmation="write $message in the developer logs"]
     #_[confirmation_remote="write $message in the developer logs on $__person's phone"]
-    #[doc="log a message in the developer logs"];
+    #[doc="log a message in the developer logs"]
+    #[confirm=false];
 
     action configure(in req device: Entity(tt:device) #_[prompt="What device do you want to configure?"])
     #_[canonical="configure"]
     #_[confirmation="configure a new $device"]
     #_[confirmation_remote="configure a new $device on $__person's Almond"]
-    #[doc="configure a specific device by type"];
+    #[doc="configure a specific device by type"]
+    #[confirm=false];
 
     action say(in req message: String #_[prompt="What do you want me to say?"])
     #_[canonical="say"]
     #_[confirmation="send me a message $message"]
     #_[confirmation_remote="send $__person message $message"]
-    #[doc="makes Almond say something; this is the codegennable version of @$notify"];
+    #[doc="makes Almond say something; this is the codegennable version of @$notify"]
+    #[confirm=false];
 
     action discover()
     #_[canonical="discover"]
     #_[confirmation="search for new devices"]
     #_[confirmation_remote="search for new devices on $__person's Almond"]
-    #[doc="start interactive discovery for new devices"];
+    #[doc="start interactive discovery for new devices"]
+    #[confirm=false];
 
     action open_url(in req url: Entity(tt:url) #_[prompt="What URL do you want to open?"])
     #_[canonical="open url on builtin"]
     #_[confirmation="open $url"]
     #_[confirmation_remote="open $url in $__person's PC"]
-    #[doc="open a file/link"];
+    #[doc="open a file/link"]
+    #[confirm=false];
   }
 
 dataset: |

--- a/data/org.thingpedia.builtin.thingengine.gnome.yaml
+++ b/data/org.thingpedia.builtin.thingengine.gnome.yaml
@@ -20,7 +20,8 @@ class: |
     #_[canonical="open app on laptop"]
     #_[confirmation="open $app_id"]
     #_[confirmation_remote="open $app_id in $__person's PC"]
-    #[doc="open the given app (optionally with a file)"];
+    #[doc="open the given app (optionally with a file)"]
+    #[confirm=false];
 
     action lock()
     #_[canonical="lock on laptop"]

--- a/data/org.thingpedia.builtin.thingengine.phone.yaml
+++ b/data/org.thingpedia.builtin.thingengine.phone.yaml
@@ -29,7 +29,8 @@ class: |
     #_[canonical="set ringer on phone"]
     #_[confirmation="set your phone to $mode"]
     #_[confirmation_remote="set $__person's phone to $mode"]
-    #[doc="set ringer mode; valid values are \"normal\", \"vibrate\" and \"silent\""];
+    #[doc="set ringer mode; valid values are \"normal\", \"vibrate\" and \"silent\""]
+    #[confirm=false];
 
     action call(in req number: Entity(tt:phone_number) #_[prompt="Who do you want to call?"] #_[canonical="number"])
     #_[canonical="make call on phone"]

--- a/model/migrations/b77ba97-function_annotation_confirm.sql
+++ b/model/migrations/b77ba97-function_annotation_confirm.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `device_schema_channels`
+  ADD `confirm` tinyint(1) NOT NULL DEFAULT 1;
+UPDATE `device_schema_channels` SET confirm = 0 WHERE `channel_type` = 'action';

--- a/model/schema.js
+++ b/model/schema.js
@@ -49,7 +49,8 @@ function insertChannels(dbClient, schemaId, schemaKind, kindType, version, langu
                            JSON.stringify(meta.is_input),
                            JSON.stringify(meta.string_values),
                            !!meta.is_list,
-                           !!meta.is_monitorable]);
+                           !!meta.is_monitorable,
+                           !!meta.confirm]);
             channelCanonicals.push([schemaId, version, language, name,
                                     meta.canonical,
                                     meta.confirmation,
@@ -68,7 +69,7 @@ function insertChannels(dbClient, schemaId, schemaKind, kindType, version, langu
         return Q();
 
     return db.insertOne(dbClient, 'insert into device_schema_channels(schema_id, version, name, '
-        + 'channel_type, doc, types, argnames, required, is_input, string_values, is_list, is_monitorable) values ?', [channels])
+        + 'channel_type, doc, types, argnames, required, is_input, string_values, is_list, is_monitorable, confirm) values ?', [channels])
         .then(() => {
             return db.insertOne(dbClient, 'insert into device_schema_channel_canonicals(schema_id, version, language, name, '
             + 'canonical, confirmation, confirmation_remote, formatted, argcanonicals, questions) values ?', [channelCanonicals]);
@@ -126,6 +127,7 @@ function processMetaRows(rows) {
             is_input: JSON.parse(row.is_input) || [],
             is_list: !!row.is_list,
             is_monitorable: !!row.is_monitorable,
+            confirm: !!row.confirm,
             confirmation: row.confirmation,
             confirmation_remote: row.confirmation_remote || row.confirmation, // for compatibility
             formatted: JSON.parse(row.formatted || '[]'),
@@ -265,7 +267,7 @@ module.exports = {
         if (org === -1) {
             return db.selectAll(client, `select dsc.name, channel_type, canonical, confirmation,
                 confirmation_remote, formatted, doc, types, argnames, argcanonicals, required, is_input,
-                is_list, is_monitorable, string_values, questions, kind, kind_canonical, kind_type
+                is_list, is_monitorable, string_values, questions, confirm, kind, kind_canonical, kind_type
                 from device_schema ds
                 left join device_schema_channels dsc on ds.id = dsc.schema_id
                 and dsc.version = ds.developer_version
@@ -275,7 +277,7 @@ module.exports = {
         } else if (org !== null) {
             return db.selectAll(client, `select dsc.name, channel_type, canonical, confirmation,
                 confirmation_remote, formatted, doc, types, argnames, argcanonicals, required, is_input,
-                is_list, is_monitorable, string_values, questions, kind, kind_canonical, kind_type
+                is_list, is_monitorable, string_values, questions, confirm, kind, kind_canonical, kind_type
                 from device_schema ds
                 left join device_schema_channels dsc on ds.id = dsc.schema_id
                 and ((dsc.version = ds.developer_version and ds.owner = ?) or
@@ -287,7 +289,7 @@ module.exports = {
         } else {
             return db.selectAll(client, `select dsc.name, channel_type, canonical, confirmation,
                 confirmation_remote, formatted, doc, types, argnames, argcanonicals, required, is_input,
-                is_list, is_monitorable, string_values, questions, kind, kind_canonical, kind_type
+                is_list, is_monitorable, string_values, questions, confirm, kind, kind_canonical, kind_type
                 from device_schema ds
                 left join device_schema_channels dsc on ds.id = dsc.schema_id
                 and dsc.version = ds.approved_version
@@ -327,7 +329,7 @@ module.exports = {
         if (org === -1) {
             return db.selectAll(client, `select dsc.name, channel_type, canonical, confirmation,
                 confirmation_remote, formatted, doc, types, argnames, argcanonicals, required, is_input,
-                is_list, is_monitorable, string_values, questions, kind, kind_canonical, kind_type
+                is_list, is_monitorable, string_values, questions, confirm, kind, kind_canonical, kind_type
                 from device_schema_snapshot ds
                 left join device_schema_channels dsc on ds.schema_id = dsc.schema_id
                 and dsc.version = ds.developer_version
@@ -338,7 +340,7 @@ module.exports = {
         } else if (org !== null) {
             return db.selectAll(client, `select dsc.name, channel_type, canonical, confirmation,
                 confirmation_remote, formatted, doc, types, argnames, argcanonicals, required, is_input,
-                is_list, is_monitorable, string_values, questions, kind, kind_canonical, kind_type
+                is_list, is_monitorable, string_values, questions, confirm, kind, kind_canonical, kind_type
                 from device_schema_snapshot ds
                 left join device_schema_channels dsc on ds.schema_id = dsc.schema_id
                 and ((dsc.version = ds.developer_version and ds.owner = ?) or
@@ -350,7 +352,7 @@ module.exports = {
         } else {
             return db.selectAll(client, `select dsc.name, channel_type, canonical, confirmation,
                 confirmation_remote, formatted, doc, types, argnames, argcanonicals, required, is_input,
-                is_list, is_monitorable, string_values, questions, kind, kind_canonical, kind_type
+                is_list, is_monitorable, string_values, questions, confirm, kind, kind_canonical, kind_type
                 from device_schema_snapshot ds
                 left join device_schema_channels dsc on ds.schema_id = dsc.schema_id
                 and dsc.version = ds.approved_version
@@ -397,7 +399,7 @@ module.exports = {
             if (org === -1) {
                 return db.selectAll(client, `select dsc.name, channel_type, canonical, confirmation,
                     confirmation_remote, formatted, doc, types, argnames, argcanonicals, required, is_input,
-                    string_values, is_list, is_monitorable, questions, kind, kind_type
+                    string_values, is_list, is_monitorable, questions, confirm, kind, kind_type
                     from device_schema ds left join
                     device_schema_channels dsc on ds.id = dsc.schema_id and
                     dsc.version = ds.developer_version left join device_schema_channel_canonicals dscc
@@ -407,7 +409,7 @@ module.exports = {
             } if (org !== null) {
                 return db.selectAll(client, `select dsc.name, channel_type, canonical, confirmation,
                     confirmation_remote, formatted, doc, types, argnames, argcanonicals, required, is_input,
-                    string_values, is_list, is_monitorable, questions, kind, kind_type
+                    string_values, is_list, is_monitorable, questions, confirm, kind, kind_type
                     from device_schema ds left join
                     device_schema_channels dsc on ds.id = dsc.schema_id and
                     ((dsc.version = ds.developer_version and ds.owner = ?) or
@@ -419,7 +421,7 @@ module.exports = {
             } else {
                 return db.selectAll(client, `select dsc.name, channel_type, canonical, confirmation,
                     confirmation_remote, formatted, doc, types, argnames, argcanonicals, required, is_input,
-                    string_values, is_list, is_monitorable, questions, kind, kind_type
+                    string_values, is_list, is_monitorable, questions, confirm, kind, kind_type
                     from device_schema ds left join device_schema_channels
                     dsc on ds.id = dsc.schema_id and dsc.version = ds.approved_version left join
                     device_schema_channel_canonicals dscc on dscc.schema_id = dsc.schema_id and
@@ -433,7 +435,7 @@ module.exports = {
     getMetasByKindAtVersion(client, kind, version, language) {
         return Q.try(() => {
             return db.selectAll(client, "select dsc.name, channel_type, canonical, confirmation, confirmation_remote, formatted, doc, types,"
-                                + " argnames, argcanonicals, required, is_input, string_values, is_list, is_monitorable, questions, kind, kind_type "
+                                + " argnames, argcanonicals, required, is_input, string_values, is_list, is_monitorable, questions, confirm, kind, kind_type "
                                 + " from device_schema ds"
                                 + " left join device_schema_channels dsc on ds.id = dsc.schema_id"
                                 + " and dsc.version = ? "

--- a/model/schema.sql
+++ b/model/schema.sql
@@ -215,6 +215,7 @@ CREATE TABLE `device_schema_channels` (
   `doc` mediumtext COLLATE utf8_bin NOT NULL,
   `is_list` tinyint(1) NOT NULL DEFAULT 1,
   `is_monitorable` tinyint(1) NOT NULL DEFAULT 1,
+  `confirm` tinyint(1) NOT NULL DEFAULT 1,
   PRIMARY KEY (`schema_id`,`version`,`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/tests/test_thingpedia_api_v1_v2.js
+++ b/tests/test_thingpedia_api_v1_v2.js
@@ -93,7 +93,8 @@ const BING_METADATA = {
               null,
               null,
               null
-            ]
+            ],
+            confirm: false
         },
         web_search: {
             schema: ["String", "String", "String", "Entity(tt:url)"],
@@ -124,7 +125,8 @@ const BING_METADATA = {
               "tt:short_free_text",
               "tt:long_free_text",
               null,
-            ]
+            ],
+            confirm: false
         }
     }
 };
@@ -203,6 +205,7 @@ async function testGetMetadata() {
                     is_list: false,
                     is_monitorable: false,
                     string_values: [null],
+                    confirm: true
                 }
             }
         }
@@ -230,7 +233,8 @@ async function testGetMetadata() {
                     canonical: "eat data on test",
                     is_list: false,
                     is_monitorable: false,
-                    string_values: [null]
+                    string_values: [null],
+                    confirm: true
                 }
             }
         }

--- a/tests/test_thingpedia_api_v3.js
+++ b/tests/test_thingpedia_api_v3.js
@@ -117,7 +117,8 @@ const BING_METADATA = {
               null,
               null,
               null
-            ]
+            ],
+            confirm: false
         },
         web_search: {
             types: ["String", "String", "String", "Entity(tt:url)"],
@@ -148,7 +149,8 @@ const BING_METADATA = {
               "tt:short_free_text",
               "tt:long_free_text",
               null,
-            ]
+            ],
+            confirm: false
         }
     }
 };
@@ -176,7 +178,8 @@ const BING_CLASS_WITH_METADATA = `class @com.bing {
                                       out height: Number #_[prompt="What height are you looking for (in pixels)?"] #_[canonical="height"])
   #_[canonical="image search on bing"]
   #_[confirmation="images matching $query from Bing"]
-  #_[formatted=[{type="rdl",webCallback="${'${link}'}",displayTitle="${'${title}'}"}, {type="picture",url="${'${picture_url}'}"}]];
+  #_[formatted=[{type="rdl",webCallback="${'${link}'}",displayTitle="${'${title}'}"}, {type="picture",url="${'${picture_url}'}"}]]
+  #[confirm=false];
 
   monitorable list query web_search(in req query: String #_[prompt="What do you want to search?"] #_[canonical="query"] #[string_values="tt:search_query"],
                                     out title: String #_[canonical="title"] #[string_values="tt:short_free_text"],
@@ -184,7 +187,8 @@ const BING_CLASS_WITH_METADATA = `class @com.bing {
                                     out link: Entity(tt:url) #_[canonical="link"])
   #_[canonical="web search on bing"]
   #_[confirmation="websites matching $query on Bing"]
-  #_[formatted=[{type="rdl",webCallback="${'${link}'}",displayTitle="${'${title}'}",displayText="${'${description}'}"}]];
+  #_[formatted=[{type="rdl",webCallback="${'${link}'}",displayTitle="${'${title}'}",displayText="${'${description}'}"}]]
+  #[confirm=false];
 }
 `;
 const BING_CLASS_FULL = `class @com.bing
@@ -203,7 +207,8 @@ const BING_CLASS_FULL = `class @com.bing
   #_[confirmation="websites matching $query on Bing"]
   #_[formatted=[{type="rdl",webCallback="${'${link}'}",displayTitle="${'${title}'}",displayText="${'${description}'}"}]]
   #[poll_interval=3600000ms]
-  #[doc="search for ${'`query`'} on Bing"];
+  #[doc="search for ${'`query`'} on Bing"]
+  #[confirm=false];
 
   monitorable list query image_search(in req query: String #_[prompt="What do you want to search?"] #_[canonical="query"] #[string_values="tt:search_query"],
                                       out title: String #_[canonical="title"] #[string_values="tt:short_free_text"],
@@ -215,7 +220,8 @@ const BING_CLASS_FULL = `class @com.bing
   #_[confirmation="images matching $query from Bing"]
   #_[formatted=[{type="rdl",webCallback="${'${link}'}",displayTitle="${'${title}'}"}, {type="picture",url="${'${picture_url}'}"}]]
   #[poll_interval=3600000ms]
-  #[doc="search for ${'`query`'} on Bing Images"];
+  #[doc="search for ${'`query`'} on Bing Images"]
+  #[confirm=false];
 }
 `;
 
@@ -230,13 +236,15 @@ const ADMINONLY_CLASS = `class @org.thingpedia.builtin.test.adminonly {
 const INVISIBLE_CLASS_WITH_METADATA = `class @org.thingpedia.builtin.test.invisible {
   action eat_data(in req data: String #_[prompt="What do you want me to consume?"] #_[canonical="data"])
   #_[canonical="eat data on test"]
-  #_[confirmation="consume $data"];
+  #_[confirmation="consume $data"]
+  #[confirm=true];
 }
 `;
 const ADMINONLY_CLASS_WITH_METADATA = `class @org.thingpedia.builtin.test.adminonly {
   action eat_data(in req data: String #_[prompt="What do you want me to consume?"] #_[canonical="data"])
   #_[canonical="eat data on test"]
-  #_[confirmation="consume $data"];
+  #_[confirmation="consume $data"]
+  #[confirm=true];
 }
 `;
 
@@ -406,7 +414,8 @@ async function testGetMetadata() {
                         canonical: "eat data on test",
                         is_list: false,
                         is_monitorable: false,
-                        string_values: [null]
+                        string_values: [null],
+                        confirm: true
                     }
                 }
             }
@@ -441,7 +450,8 @@ async function testGetMetadata() {
                         canonical: "eat data on test",
                         is_list: false,
                         is_monitorable: false,
-                        string_values: [null]
+                        string_values: [null],
+                        confirm: true
                     }
                 }
             }
@@ -488,7 +498,8 @@ async function testGetMetadata() {
                         canonical: "eat data on test",
                         is_list: false,
                         is_monitorable: false,
-                        string_values: [null]
+                        string_values: [null],
+                        confirm: true
                     }
                 }
             }
@@ -2034,7 +2045,8 @@ const BANG_CLASS_FULL = `class @com.bing
   #_[confirmation="websites matching $query on Bing"]
   #_[formatted=[{type="rdl",webCallback="${'${link}'}",displayTitle="${'${title}'}",displayText="${'${description}'}"}]]
   #[poll_interval=3600000ms]
-  #[doc="search for ${'`query`'} on Bing"];
+  #[doc="search for ${'`query`'} on Bing"]
+  #[confirm=false];
 
   monitorable list query image_search(in req query: String #_[prompt="What do you want to search?"] #_[canonical="query"] #[string_values="tt:search_query"],
                                       out title: String #_[canonical="title"] #[string_values="tt:short_free_text"],
@@ -2046,7 +2058,8 @@ const BANG_CLASS_FULL = `class @com.bing
   #_[confirmation="images matching $query from Bing"]
   #_[formatted=[{type="rdl",webCallback="${'${link}'}",displayTitle="${'${title}'}"}, {type="picture",url="${'${picture_url}'}"}]]
   #[poll_interval=3600000ms]
-  #[doc="search for ${'`query`'} on Bing Images"];
+  #[doc="search for ${'`query`'} on Bing Images"]
+  #[confirm=false];
 }
 `;
 
@@ -2143,7 +2156,8 @@ async function testCreateDevice() {
 
   query foo(out text: String #_[canonical="text"])
   #_[confirmation="the foos"]
-  #_[canonical="foo on new test device"];
+  #_[canonical="foo on new test device"]
+  #[confirm=false];
 }
 `);
 

--- a/util/manifest_to_schema.js
+++ b/util/manifest_to_schema.js
@@ -55,6 +55,8 @@ function makeSchemaFunctionDef(functionType, functionName, schema, isMeta) {
             metadata.formatted = schema.formatted;
     }
     const annotations = {};
+    if (isMeta)
+        annotations.confirm = Ast.Value.Boolean(schema.confirm);
 
     return new Ast.FunctionDef(functionType,
                                functionName,
@@ -145,6 +147,7 @@ module.exports = {
                     formatted: fnDef.metadata.formatted || [],
                     is_list: fnDef.is_list,
                     is_monitorable: fnDef.is_monitorable,
+                    confirm: fnDef.annotations.confirm.toJS(),
                     types: [],
                     args: [],
                     argcanonicals: [],

--- a/util/validation.js
+++ b/util/validation.js
@@ -250,6 +250,15 @@ function validateInvocation(kind, where, what, entities, stringTypes, options = 
             throw new ValidationError(`Detected placeholder in canonical form for ${name}: this is incorrect, the canonical form must not contain parameters`);
         if (!where[name].metadata.confirmation)
             throw new ValidationError(`Missing confirmation for ${name}`);
+        if (where[name].annotations.confirm) {
+            if (!where[name].annotations.confirm.isBoolean)
+                throw new ValidationError(`Invalid #[confirm] annotation for ${name}, must be a Boolean`);
+        } else {
+            if (what === 'query')
+                where[name].annotations.confirm = ThingTalk.Ast.Value.Boolean(false);
+            else
+                where[name].annotations.confirm = ThingTalk.Ast.Value.Boolean(true);
+        }
         if (options.checkPollInterval && what === 'query' && where[name].is_monitorable) {
             if (!where[name].annotations.poll_interval)
                 throw new ValidationError(`Missing poll interval for monitorable query ${name}`);


### PR DESCRIPTION
almond-dialog-agent has started honoring the `#[confirm]` annotation on functions. We need to make sure all functions have it or we will regress.