### PR TITLE
training: mark evaluation candidate examples correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "express-session": "^1.14.0",
     "express-ws": "^4.0.0",
     "express-xml-bodyparser": "^0.3.0",
-    "genie-toolkit": "~0.4.0",
+    "genie-toolkit": "~0.4.1",
     "gettext-parser": "^4.0.0",
     "gm": "^1.23.1",
     "highlight.js": "^9.13.1",

--- a/tests/thingpedia-integration.sh
+++ b/tests/thingpedia-integration.sh
@@ -179,7 +179,7 @@ mkdir jobdir
 sha256sum exact.tsv jobdir/eval.tsv jobdir/train.tsv
 sha256sum -c <<EOF
 15bc13b7c0f964eb4bbb0d851707c5e702d575eb463be6a3d18948e49e3a3442  exact.tsv
-72bccb2f8b7d4c6b6556eb5c998374c0b10b1e78c56f3ba7f72ea08cd5a8f240  jobdir/eval.tsv
+16fbf8cff849786fb4ccfba29be834b52158f94136ecddb4e92508b611d40e95  jobdir/eval.tsv
 ccf5b85172720d6e22da4a3e010bf7227ec600755926bb2cb3c5712667d60701  jobdir/train.tsv
 EOF
 

--- a/training/prepare-training-set.js
+++ b/training/prepare-training-set.js
@@ -43,10 +43,9 @@ class QueryReadableAdapter extends Stream.Readable {
 
         query.on('result', (row) => {
             row.flags = parseFlags(row.flags);
-            // treat paraphrase data as synthetic, which will prevent
-            // from evaluating on it
-            if (!row.flags.exact)
-                row.flags.synthetic = true;
+            // mark a sentence for evaluation only if is exact and not synthetic,
+            // which means it comes from the online dataset (developer data)
+            row.flags.eval = row.flags.exact && !row.flags.synthetic;
             this.push(row);
         });
         query.on('end', () => {
@@ -180,6 +179,7 @@ class DatasetGenerator {
             evalProbability: this._options.evalProbability,
             forDevices: this._forDevices,
             splitStrategy: this._options.splitStrategy,
+            useEvalFlag: true
         });
 
         source.pipe(augmenter).pipe(splitter);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2661,10 +2661,10 @@ gcp-metadata@^1.0.0:
     gaxios "^1.0.2"
     json-bigint "^0.3.0"
 
-genie-toolkit@~0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/genie-toolkit/-/genie-toolkit-0.4.0.tgz#91fec5ec6916fe9a8b8b6b6bc89dc80841003ac6"
-  integrity sha512-DGPYZ3pcH3GX2RgtbslIhFwuZWXX9/46dNGDXnIHtofSKMNHAFwp8iWAtMxhqbRNghB+u+si4ILKfhDVyHgIIw==
+genie-toolkit@~0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/genie-toolkit/-/genie-toolkit-0.4.1.tgz#b375aed82fd4b93cf482b513b5c9ffa8ed91bb21"
+  integrity sha512-68uXGaFEMZyQRZ1NlQirEGSeY1NXsLixW5dCNAWLizmGxk0I6qVth4yFn6v5jCKZ0KS4uByRlFF7tpM5DPQ3lA==
   dependencies:
     argparse "^1.0.10"
     byline "^5.0.0"


### PR DESCRIPTION
Our current hack of marking paraphrases as synthetic breaks the
balance between paraphrase and synthetic (which comes during
augmentation and uses the flags), resulting in poorer models.
Instead, use the new flag in genie to avoid evaluating on paraphrases

Depends on https://github.com/stanford-oval/genie-toolkit/pull/84 to have any effect