### PR TITLE
Stricter validation rules for IDs

### DIFF
--- a/routes/developer_alexa.js
+++ b/routes/developer_alexa.js
@@ -19,6 +19,7 @@ const userModel = require('../model/user');
 const schemaModel = require('../model/schema');
 const user = require('../util/user');
 const { ForbiddenError, NotFoundError, BadRequestError } = require('../util/errors');
+const { validateTag } = require('../util/validation');
 const DatasetUtils = require('../util/dataset');
 const { clean } = require('../util/tokenize');
 const iv = require('../util/input_validation');
@@ -42,6 +43,7 @@ router.post('/create', user.requireLogIn, user.requireDeveloper(),
     if (!I18n.get(req.body.language))
         throw new BadRequestError(req._("Unsupported language"));
     const language = I18n.localeToLanguage(req.body.language);
+    validateTag(req.body.tag, req.user, user.Role.NLP_ADMIN);
 
     db.withTransaction(async (dbClient) => {
         try {

--- a/routes/luinet_models.js
+++ b/routes/luinet_models.js
@@ -17,6 +17,7 @@ const nlpModelsModel = require('../model/nlp_models');
 const templateModel = require('../model/template_files');
 const schemaModel = require('../model/schema');
 const iv = require('../util/input_validation');
+const { validateTag } = require('../util/validation');
 const { ForbiddenError, NotFoundError, BadRequestError } = require('../util/errors');
 const I18n = require('../util/i18n');
 const { makeRandom } = require('../util/random');
@@ -31,6 +32,8 @@ router.post('/create', user.requireLogIn, user.requireDeveloper(),
     if (!I18n.get(req.body.language))
         throw new BadRequestError(req._("Unsupported language"));
     const language = I18n.localeToLanguage(req.body.language);
+
+    validateTag(req.body.tag, req.user, user.Role.NLP_ADMIN);
 
     db.withTransaction(async (dbClient) => {
         try {

--- a/routes/luinet_templates.js
+++ b/routes/luinet_templates.js
@@ -21,6 +21,7 @@ const user = require('../util/user');
 const model = require('../model/template_files');
 const platform = require('../util/platform');
 const iv = require('../util/input_validation');
+const { validateTag } = require('../util/validation');
 const { ForbiddenError, BadRequestError } = require('../util/errors');
 const I18n = require('../util/i18n');
 const code_storage = require('../util/code_storage');
@@ -66,6 +67,8 @@ async function uploadTemplatePack(req) {
 
         if (req.body.flags && !/^[a-zA-Z_][0-9a-zA-Z_]*(?:[ ,][a-zA-Z_][0-9a-zA-Z_]*)*$/.test(req.body.flags))
             throw new BadRequestError(req._("Invalid flags"));
+
+        validateTag(req.body.tag, req.user, user.Role.NLP_ADMIN);
 
         const flags = req.body.flags ? req.body.flags.split(/[ ,]/g) : [];
         if (flags.indexOf('turking') < 0)

--- a/util/errors.js
+++ b/util/errors.js
@@ -23,9 +23,9 @@ class BadRequestError extends HTTPError {
     }
 }
 
-class ValidationError extends Error {
+class ValidationError extends HTTPError {
     constructor(message) {
-        super(message);
+        super(400, message);
         this.code = 'EINVAL';
     }
 }

--- a/util/upload_dataset.js
+++ b/util/upload_dataset.js
@@ -16,7 +16,7 @@ const schemaModel = require('../model/schema');
 const entityModel = require('../model/entity');
 const stringModel = require('../model/strings');
 
-const NAME_REGEX = /([A-Za-z_][A-Za-z0-9_.-]*):([A-Za-z_][A-Za-z0-9_]*)/;
+const NAME_REGEX = /^([A-Za-z_][A-Za-z0-9_.-]*):([A-Za-z_][A-Za-z0-9_]*)$/;
 
 class StreamTokenizer extends Stream.Transform {
     constructor(options) {

--- a/util/user.js
+++ b/util/user.js
@@ -52,7 +52,7 @@ function isAuthenticated(req) {
     return req.session.completed2fa;
 }
 
-const INVALID_USERNAMES = new Set('admin,moderator,administrator,mod,sys,system,community,info,you,name,username,user,nickname,discourse,discourseorg,discourseforum,support,hp,account-created,password-reset,admin-login,confirm-admin,account-created,activate-account,confirm-email-token,authorize-email,stanfordalmond,almondstanford'.split(','));
+const INVALID_USERNAMES = new Set('admin,moderator,administrator,mod,sys,system,community,info,you,name,username,user,nickname,discourse,discourseorg,discourseforum,support,hp,account-created,password-reset,admin-login,confirm-admin,account-created,activate-account,confirm-email-token,authorize-email,stanfordalmond,almondstanford,almond,root,noreply,stanford'.split(','));
 
 const MAX_USERNAME_LENGTH = 60;
 

--- a/util/validation.js
+++ b/util/validation.js
@@ -20,6 +20,7 @@ const TokenizerService = require('./tokenizer_service');
 const ThingpediaClient = require('./thingpedia-client');
 const getExampleName = require('./example_names');
 const { ValidationError } = require('./errors');
+const userUtils = require('./user');
 
 assert(typeof ThingpediaClient === 'function');
 
@@ -32,7 +33,7 @@ const SUBCATEGORIES = new Set(['service','media','social-network','communication
 const FORBIDDEN_NAMES = new Set(['__count__', '__noSuchMethod__', '__parent__',
 '__proto__', 'constructor', '__defineGetter__', '__defineSetter__', '__lookupGetter__',
 '__lookupSetter__', 'eval', 'hasOwnProperty', 'isPrototypeOf', 'propertyIsEnumerable',
-'toLocaleString', 'toSource', 'toString', 'unwatch', 'watch', 'valueOf']);
+'toLocaleString', 'toSource', 'toString', 'valueOf']);
 
 const ALLOWED_ARG_METADATA = new Set(['canonical', 'prompt']);
 const ALLOWED_FUNCTION_METADATA = new Set(['canonical', 'confirmation', 'confirmation_remote', 'formatted']);
@@ -86,8 +87,6 @@ async function loadClassDef(dbClient, req, kind, classCode, datasetCode) {
     return [classDef, dataset];
 }
 
-const LEGACY_KINDS = ['security-camera', 'car', 'messaging', 'light-bulb', 'smoke-alarm', 'thermostat'];
-
 async function validateDevice(dbClient, req, options, classCode, datasetCode) {
     const name = options.name;
     const description = options.description;
@@ -96,17 +95,13 @@ async function validateDevice(dbClient, req, options, classCode, datasetCode) {
 
     if (!name || !description || !kind || !license)
         throw new ValidationError("Not all required fields were present");
-    if (Buffer.from(kind, 'utf8').length > 128)
-        throw new ValidationError("The chosen identifier is too long");
+    validateTag(kind, req.user, userUtils.Role.THINGPEDIA_ADMIN);
 
     if (!SUBCATEGORIES.has(options.subcategory))
         throw new ValidationError(req._("Invalid device category %s").format(options.subcategory));
     const [classDef, dataset] = await loadClassDef(dbClient, req, kind, classCode, datasetCode);
     validateMetadata(classDef.metadata, ALLOWED_CLASS_METADATA);
     validateAnnotations(classDef.annotations);
-
-    if (kind.indexOf('.') < 0 && LEGACY_KINDS.indexOf(kind) < 0)
-        throw new ValidationError(`Invalid device ID ${kind}: must contain at least one period`);
 
     if (!classDef.is_abstract) {
         if (!classDef.loader)
@@ -223,8 +218,6 @@ function validateUtterance(args, utterance) {
 }
 
 function validateAllInvocations(classDef, options = {}) {
-    if (FORBIDDEN_NAMES.has(classDef.kind))
-        throw new ValidationError(`${classDef.kind} is not allowed as a device ID`);
 
     let entities = new Set;
     let stringTypes = new Set;
@@ -377,6 +370,50 @@ async function tokenizeDataset(dataset) {
     }));
 }
 
+
+function validateTag(tag, user, adminRole) {
+    // first the security/well-formedness checks
+    // the name must be a valid DNS name: multiple parts separated
+    // by '.'; each part must be alphanumeric, -, or _,
+    // and must be both a valid hostname and a valid ThingTalk class-identifier
+    // (not start or end with -, not start with a number)
+    if (!/^([A-Za-z_][A-Za-z0-9_.-]*)$/.test(tag))
+        throw new ValidationError(`Invalid ID ${tag}`);
+
+    const parts = tag.split('.');
+    for (let part of parts) {
+        if (part.length === 0 || /^[-0-9]/.test(part) || part.endsWith('-'))
+            throw new ValidationError(`Invalid ID ${tag}`);
+
+        // JS reserved words and unsafe names are forbidden
+        if (FORBIDDEN_NAMES.has(part))
+            throw new ValidationError(`${tag} is not allowed as ID because it contains the unsafe keyword ${part}`);
+    }
+
+    if (Buffer.from(tag, 'utf8').length > 128)
+        throw new ValidationError("The chosen identifier is too long");
+
+    // now the naming convention checks
+
+    // if there is an admin role in this context, and the user has it, anything is allowed
+    if (adminRole !== undefined && (user.roles & adminRole) === adminRole)
+        return;
+
+    // otherwise, single part names (no dots) are always disallowed
+    // names in the org.thingpedia namespace are also disallowed
+
+    if (parts.length <= 1)
+        throw new ValidationError(`Invalid ID ${tag}: must contain at least one period`);
+
+    if (parts[0] === 'org' && parts[1] === 'thingpedia') {
+        // ignore the 'org.thingpedia.builtin.test' and 'org.thingpedia.test' namespaces, which are free-for-all
+        if (parts[2] === 'test' || (parts[2] === 'builtin' && parts[3] === 'test'))
+            return;
+
+        throw new ValidationError(`Invalid ID ${tag}: the @org.thingpedia namespace is reserved`);
+    }
+}
+
 module.exports = {
     ValidationError,
 
@@ -385,6 +422,7 @@ module.exports = {
 
     validateDevice,
     validateDataset,
+    validateTag,
 
     tokenizeDataset,
 };


### PR DESCRIPTION
I originally wanted to enforce a rule that names with two parts must use the username as the first part, but that breaks the many devices which simply use the real domain as ID (like `com.bing`, `gov.nasa` or `ca.randomfox`), and listing all the valid TLDs would be problematic. So no rule.
Still, there are a bunch of tightenings in this PRs, like no consecutive periods, or no parts that begin with a number or "-".