### PR TITLE
frontend: move static assets to the /assets URL

### DIFF
--- a/config.js
+++ b/config.js
@@ -114,7 +114,7 @@ module.exports.THINGPEDIA_URL = 'https://thingpedia.stanford.edu/thingpedia';
   Where to store icons and zip files.
 
   Set this option to s3 to use Amazon S3, local to use the local filesystem
- (which must be configured with the correct permissions).
+  (which must be configured with the correct permissions).
 */
 module.exports.FILE_STORAGE_BACKEND = 'local';
 
@@ -130,16 +130,14 @@ module.exports.CDN_HOST = '/download';
 /**
   The CDN to use for website assets (javascript, css, images files contained in public/ )
 
-  If you are using CloudFront+S3, you can use `./scripts/sync-assets-to-s3.sh ${s3_bucket}`
-  to upload the assets. If you are using CloudFront+ELB, you can simply point the
-  CDN to the almond-cloud website; the website will act as origin server for the content
-  and set appropriate cache headers.
+  You should configure your CDN to map the URL you specify here to the /assets
+  path on the frontend server (SERVER_ORIGIN setting).
 
   Use a fully qualified URL (including https://) and omit the trailing slash.
-  Leave blank if you do not want to use a CDN, in which case assets will
-  be loaded directly from the almond-cloud website.
+  Use the default `/assets` if you do not want to use a CDN, in which case assets will
+  be loaded directly from your configured frontend server.
 */
-module.exports.ASSET_CDN = '';
+module.exports.ASSET_CDN = '/assets';
 
 /**
   The origin (scheme, hostname, port) where the server is reachable.

--- a/frontend.js
+++ b/frontend.js
@@ -42,6 +42,7 @@ const userUtils = require('./util/user');
 const platform = require('./util/platform');
 const Metrics = require('./util/metrics');
 const errorHandling = require('./util/error_handling');
+const codeStorage = require('./util/code_storage');
 const EngineManager = require('./almond/enginemanagerclient');
 
 const Config = require('./config');
@@ -168,8 +169,9 @@ class Frontend {
             next();
         });
         this._app.use(favicon(__dirname + '/public/images/favicon.ico'));
-        this._app.use(express.static(path.join(__dirname, 'public'),
-                                     { maxAge: 86400000 }));
+        this._app.use('/assets', express.static(path.join(__dirname, 'public'),
+                                                { maxAge: 86400000 }));
+        codeStorage.initFrontend(this._app);
         this._app.use(cacheable());
         passportUtil.initialize();
 

--- a/tests/nlp-integration.sh
+++ b/tests/nlp-integration.sh
@@ -57,11 +57,9 @@ node $srcdir/tests/mock-tokenizer.js &
 tokenizerpid=$!
 
 # set up download directories
-mkdir -p $srcdir/public/download
-for x in blog-assets template-files/en ; do
-    mkdir -p $workdir/shared/$x
-    mkdir -p $srcdir/public/download/$(dirname $x)
-    ln -sf -T $workdir/shared/$x $srcdir/public/download/$x
+mkdir -p $workdir/shared/download
+for x in template-files/en ; do
+    mkdir -p $workdir/shared/download/$x
 done
 mkdir -p $workdir/shared/cache
 echo '{"tt:stock_id:goog": "fb80c6ac2685d4401806795765550abdce2aa906.png"}' > $workdir/shared/cache/index.json

--- a/tests/thingpedia-integration.sh
+++ b/tests/thingpedia-integration.sh
@@ -48,11 +48,9 @@ oldpwd=`pwd`
 cd $workdir
 
 # set up download directories
-mkdir -p $srcdir/public/download
+mkdir -p $workdir/shared/download
 for x in devices icons backgrounds blog-assets template-files/en ; do
-    mkdir -p $workdir/shared/$x
-    mkdir -p $srcdir/public/download/$(dirname $x)
-    ln -sf -T $workdir/shared/$x $srcdir/public/download/$x
+    mkdir -p $workdir/shared/download/$x
 done
 mkdir -p $workdir/shared/cache
 echo '{"tt:stock_id:goog": "fb80c6ac2685d4401806795765550abdce2aa906.png"}' > $workdir/shared/cache/index.json

--- a/tests/webalmond-integration.sh
+++ b/tests/webalmond-integration.sh
@@ -57,10 +57,9 @@ oldpwd=`pwd`
 cd $workdir
 
 # set up download directories
-mkdir -p $srcdir/public/download
+mkdir -p $workdir/shared/download
 for x in blog-assets ; do
-    mkdir -p $workdir/shared/$x
-    ln -sf -T $workdir/shared/$x $srcdir/public/download/$x
+    mkdir -p $workdir/shared/download/$x
 done
 
 node $srcdir/tests/load_test_webalmond.js

--- a/util/code_storage.js
+++ b/util/code_storage.js
@@ -12,6 +12,7 @@
 const fs = require('fs');
 const Q = require('q');
 const Url = require('url');
+const express = require('express');
 const sanitize = require('sanitize-filename');
 
 const Config = require('../config');
@@ -48,6 +49,9 @@ if (Config.FILE_STORAGE_BACKEND === 's3') {
                         logger: process.stdout });
 
     _backend = {
+        initFrontend(app) {
+            // nothing to do to initialize S3
+        },
         storeIcon(blob, name) {
             var s3 = new AWS.S3();
             var upload = s3.upload({ Bucket: 'thingpedia2',
@@ -101,23 +105,26 @@ if (Config.FILE_STORAGE_BACKEND === 's3') {
     };
 } else if (Config.FILE_STORAGE_BACKEND === 'local') {
     _backend = {
+        initFrontend(app) {
+            app.use('/download', express.static(platform.getWritableDir() + '/download'));
+        },
         storeIcon(blob, name) {
-            return writeFile(blob, platform.getWritableDir() + '/icons/' + name + '.png');
+            return writeFile(blob, platform.getWritableDir() + '/download/icons/' + name + '.png');
         },
         storeBackground(blob, name) {
-            return writeFile(blob, platform.getWritableDir() + '/backgrounds/' + name + '.png');
+            return writeFile(blob, platform.getWritableDir() + '/download/backgrounds/' + name + '.png');
         },
         storeBlogAsset(blob, name, contentType = 'application/octet-stream') {
-            return writeFile(blob, platform.getWritableDir() + '/blog-assets/' + name);
+            return writeFile(blob, platform.getWritableDir() + '/download/blog-assets/' + name);
         },
         downloadZipFile(name, version, directory = 'devices') {
             name = sanitize(name);
-            let filename = platform.getWritableDir() + '/' + directory + '/' + name + '-v' + version + '.zip';
+            let filename = platform.getWritableDir() + '/download/' + directory + '/' + name + '-v' + version + '.zip';
             return fs.createReadStream(filename);
         },
         storeZipFile(blob, name, version, directory = 'devices') {
             name = sanitize(name);
-            let filename = platform.getWritableDir() + '/' + directory + '/' + name + '-v' + version + '.zip';
+            let filename = platform.getWritableDir() + '/download/' + directory + '/' + name + '-v' + version + '.zip';
             return writeFile(blob, filename);
         },
         getDownloadLocation


### PR DESCRIPTION
Separate static assets (CSS, JS, images, etc.) in /public (=> /assets) from
downloadable code in ./shared/download (=> /download).

This way, the asset CDN can be set to have the frontend server as the origin
server directly, without an extra step of copying to S3, and also
we avoid symlinks in /public if there is no S3/CDN.

Fixes #413 