### PR TITLE
Support multiple configuration files

### DIFF
--- a/almond/almond_api.js
+++ b/almond/almond_api.js
@@ -14,12 +14,12 @@ const Ast = ThingTalk.Ast;
 const Formatter = ThingTalk.Formatter;
 const { ParserClient } = require('almond-dialog-agent');
 
-const Config = require('../config');
+const PlatformModule = require('./platform');
 
 module.exports = class AlmondApi {
-    constructor(engine) {
+    constructor(engine, options) {
         this._engine = engine;
-        this._parser = new ParserClient(Config.NL_SERVER_URL, engine.platform.locale, engine.platform.getSharedPreferences());
+        this._parser = new ParserClient(PlatformModule.nlServerUrl, engine.platform.locale, engine.platform.getSharedPreferences());
         this._formatter = new Formatter(this._engine.platform.locale, this._engine.platform.timezone, this._engine.schemas);
 
         this._outputs = new Set;
@@ -46,7 +46,7 @@ module.exports = class AlmondApi {
         return Promise.resolve(this._formatter.formatForType(outputType, outputValue, 'messages')).then((messages) => {
             this._sendWs({ result: {
                 appId: appId,
-                icon: icon ? Config.CDN_HOST + '/icons/' + icon + '.png' : null,
+                icon: icon ? PlatformModule.cdnHost + '/icons/' + icon + '.png' : null,
                 raw: outputValue,
                 type: outputType,
                 formatted: messages
@@ -57,7 +57,7 @@ module.exports = class AlmondApi {
     notifyError(appId, icon, error) {
         this._sendWs({ error: {
             appId: appId,
-            icon: icon ? Config.CDN_HOST + '/icons/' + icon + '.png' : null,
+            icon: icon ? PlatformModule.cdnHost + '/icons/' + icon + '.png' : null,
             error: error
         }});
     }
@@ -172,7 +172,7 @@ module.exports = class AlmondApi {
                 uniqueId: app.uniqueId,
                 description: app.description,
                 code: app.code,
-                icon: Config.CDN_HOST + '/icons/' + app.icon + '.png',
+                icon: PlatformModule.cdnHost + '/icons/' + app.icon + '.png',
                 results, errors
             };
         } catch (e) {
@@ -238,7 +238,7 @@ module.exports = class AlmondApi {
                 name: device.name,
                 description: device.description,
                 kind: device.kind,
-                icon: Config.CDN_HOST + '/icons/' + device.kind + '.png',
+                icon: PlatformModule.cdnHost + '/icons/' + device.kind + '.png',
             };
         }
 

--- a/almond/assistant.js
+++ b/almond/assistant.js
@@ -14,8 +14,7 @@ const events = require('events');
 const Almond = require('almond-dialog-agent');
 const AlmondApi = require('./almond_api');
 const TimedCache = require('../util/timed_cache');
-
-const Config = require('../config');
+const PlatformModule = require('./platform');
 
 const CONVERSATION_TTL = 300000; // 5 minutes
 
@@ -27,7 +26,7 @@ module.exports = class Assistant extends events.EventEmitter {
     constructor(engine, options) {
         super();
 
-        this._url = Config.NL_SERVER_URL;
+        this._url = PlatformModule.nlServerUrl;
         if (options.modelTag !== null &&
             options.modelTag !== 'default' &&
             options.modelTag !== 'org.thingpedia.models.default')

--- a/almond/enginemanager.js
+++ b/almond/enginemanager.js
@@ -97,7 +97,8 @@ class EngineProcess extends events.EventEmitter {
             locale: user.locale,
             timezone: user.timezone,
             storageKey: user.storage_key,
-            modelTag: user.model_tag || 'default' }]);
+            modelTag: user.model_tag || 'default',
+        }]);
     }
 
     killEngine(userId) {
@@ -187,6 +188,15 @@ class EngineProcess extends events.EventEmitter {
         });
     }
 
+    _addConfigArgs(args) {
+        args.push(
+            '--thingpedia-url', Config.THINGPEDIA_URL,
+            '--nl-server-url', Config.NL_SERVER_URL,
+            '--cdn-host', Config.CDN_HOST,
+            '--oauth-redirect-origin', Config.OAUTH_REDIRECT_ORIGIN
+        );
+    }
+
     start() {
         const ALLOWED_ENVS = ['LANG', 'LOGNAME', 'USER', 'PATH',
                               'HOME', 'SHELL', 'THINGENGINE_PROXY',
@@ -217,6 +227,7 @@ class EngineProcess extends events.EventEmitter {
             args = process.execArgv.slice();
             args.push(enginePath);
             args.push('--shared');
+            this._addConfigArgs(args);
             child = child_process.spawn(process.execPath, args,
                                         { stdio: ['ignore', 'ignore', 2, 'ignore', 'ipc'],
                                           detached: true, // ignore ^C
@@ -226,11 +237,13 @@ class EngineProcess extends events.EventEmitter {
                 processPath = process.execPath;
                 args = process.execArgv.slice();
                 args.push(enginePath);
+                this._addConfigArgs(args);
                 stdio = ['ignore', 1, 2, 'ignore', 'ipc'];
             } else {
                 processPath = path.resolve(managerPath, '../sandbox/sandbox');
                 args = [process.execPath].concat(process.execArgv);
                 args.push(enginePath);
+                this._addConfigArgs(args);
                 stdio = ['ignore', 1, 2, 'pipe', 'ipc'];
 
                 const jsPrefix = path.resolve(path.dirname(managerPath));

--- a/almond/platform.js
+++ b/almond/platform.js
@@ -24,8 +24,6 @@ const Assistant = require('./assistant');
 const graphics = require('./graphics');
 const i18n = require('../util/i18n');
 
-const Config = require('../config');
-
 var _unzipApi = {
     unzip(zipPath, dir) {
         var args = ['-uo', zipPath, '-d', dir];
@@ -232,7 +230,7 @@ class Platform extends Tp.BasePlatform {
             return true;
 
         case 'thingpedia-client':
-            return Config.WITH_THINGPEDIA === 'embedded';
+            return module.exports.thingpediaUrl === '/thingpedia';
 
         case 'graphics-api':
         case 'webhook-api':
@@ -368,8 +366,22 @@ var _shared;
 module.exports = {
     // Initialize the platform code
     // Will be called before instantiating the engine
-    init(shared) {
-        _shared = shared;
+    init(options) {
+        _shared = options.shared;
+        this._thingpediaUrl = options.thingpedia_url;
+        this._nlServerUrl = options.nl_server_url;
+        this._cdnHost = options.cdn_host;
+        this._oauthRedirectOrigin = options.oauth_redirect_origin;
+    },
+
+    get thingpediaUrl() {
+        return this._thingpediaUrl;
+    },
+    get nlServerUrl() {
+        return this._nlServerUrl;
+    },
+    get cdnHost() {
+        return this._cdnHost;
     },
 
     get shared() {
@@ -382,8 +394,7 @@ module.exports = {
 
     // for compat with existing code that does platform.getOrigin()
     getOrigin() {
-        // Xor these comments for testing
-        return Config.OAUTH_REDIRECT_ORIGIN;
+        return this._oauthRedirectOrigin;
     },
 
     // Check if this platform has the required capability

--- a/almond/platform.js
+++ b/almond/platform.js
@@ -20,7 +20,6 @@ const smtlib = require('smtlib');
 const smtsolver = smtlib.LocalCVC4Solver;
 const Tp = require('thingpedia');
 
-const Assistant = require('./assistant');
 const graphics = require('./graphics');
 const i18n = require('../util/i18n');
 
@@ -172,10 +171,8 @@ class Platform extends Tp.BasePlatform {
         return this._timezone;
     }
 
-    createAssistant(engine, options) {
-        this._assistant = new Assistant(engine, options);
-        // for compat
-        engine.assistant = this._assistant;
+    _setAssistant(assistant) {
+        this._assistant = assistant;
     }
 
     // Return the platform device for this platform, accessing platform-specific

--- a/almond/worker.js
+++ b/almond/worker.js
@@ -23,6 +23,7 @@ const argparse = require('argparse');
 const Engine = require('thingengine-core');
 const PlatformModule = require('./platform');
 const JsonDatagramSocket = require('../util/json_datagram_socket');
+const Assistant = require('./assistant');
 
 class ParentProcessSocket extends stream.Duplex {
     constructor() {
@@ -62,14 +63,19 @@ function handleSignal() {
 }
 
 function runEngine(thingpediaClient, options) {
-    var platform = PlatformModule.newInstance(thingpediaClient, options);
+    const platform = PlatformModule.newInstance(thingpediaClient, options);
     if (!PlatformModule.shared)
         global.platform = platform;
 
-    var obj = { cloudId: options.cloudId, running: false, sockets: new Set };
-    var engine = new Engine(platform, { thingpediaUrl: PlatformModule.thingpediaUrl });
+    const obj = { cloudId: options.cloudId, running: false, sockets: new Set };
+    const engine = new Engine(platform, { thingpediaUrl: PlatformModule.thingpediaUrl });
     obj.engine = engine;
-    platform.createAssistant(engine, options);
+
+    const assistant = new Assistant(engine, options);
+    platform._setAssistant(assistant);
+    // for compat
+    engine.assistant = this._assistant;
+
     engine.open().then(() => {
         obj.running = true;
 

--- a/config.js
+++ b/config.js
@@ -140,6 +140,15 @@ module.exports.CDN_HOST = '/download';
 module.exports.ASSET_CDN = '/assets';
 
 /**
+  Which branding to use for the website.
+
+  Valid values are "generic" (no branding) or "stanford" (Stanford University logo and
+  footer). Note that the Stanford University logo is a registered trademark, and therefore
+  using "stanford" branding requires permission.
+*/
+module.exports.USE_BRAND = 'generic';
+
+/**
   The origin (scheme, hostname, port) where the server is reachable.
 
   This is used for redirects and CORS checks.

--- a/doc/almond-config-file-reference.md
+++ b/doc/almond-config-file-reference.md
@@ -106,7 +106,7 @@ Default value: `'https://thingpedia.stanford.edu/thingpedia'`
 Where to store icons and zip files.
 
 Set this option to s3 to use Amazon S3, local to use the local filesystem
-which must be configured with the correct permissions).
+(which must be configured with the correct permissions).
 
 Default value: `'local'`
 
@@ -122,16 +122,23 @@ Default value: `'/download'`
 ## ASSET_CDN
 The CDN to use for website assets (javascript, css, images files contained in public/ )
 
-If you are using CloudFront+S3, you can use `./scripts/sync-assets-to-s3.sh ${s3_bucket}`
-to upload the assets. If you are using CloudFront+ELB, you can simply point the
-CDN to the almond-cloud website; the website will act as origin server for the content
-and set appropriate cache headers.
+You should configure your CDN to map the URL you specify here to the /assets
+path on the frontend server (SERVER_ORIGIN setting).
 
 Use a fully qualified URL (including https://) and omit the trailing slash.
-Leave blank if you do not want to use a CDN, in which case assets will
-be loaded directly from the almond-cloud website.
+Use the default `/assets` if you do not want to use a CDN, in which case assets will
+be loaded directly from your configured frontend server.
 
-Default value: `''`
+Default value: `'/assets'`
+
+## USE_BRAND
+Which branding to use for the website.
+
+Valid values are "generic" (no branding) or "stanford" (Stanford University logo and
+footer). Note that the Stanford University logo is a registered trademark, and therefore
+using "stanford" branding requires permission.
+
+Default value: `'generic'`
 
 ## SERVER_ORIGIN
 The origin (scheme, hostname, port) where the server is reachable.

--- a/stanford/config.js
+++ b/stanford/config.js
@@ -17,7 +17,7 @@
 // gettext marker
 function _(x) { return x; }
 
-module.exports.USE_STANFORD_BRAND = true;
+module.exports.USE_BRAND = 'stanford';
 module.exports.WITH_THINGPEDIA = 'embedded';
 module.exports.THINGPEDIA_URL = '/thingpedia';
 module.exports.SERVER_ORIGIN = 'https://almond.stanford.edu';

--- a/tests/nlp-integration.sh
+++ b/tests/nlp-integration.sh
@@ -20,19 +20,7 @@ export SECRET_KEY
 
 export THINGENGINE_USE_TOKENIZER=local
 
-NLP_PORT=${NLP_PORT:-8400}
-TRAINING_PORT=${TRAINING_PORT:-8090}
 cat > $srcdir/secret_config.js <<EOF
-module.exports.NL_SERVER_URL = 'http://127.0.0.1:${NLP_PORT}';
-module.exports.TRAINING_URL = 'http://127.0.0.1:${TRAINING_PORT}';
-module.exports.FILE_STORAGE_BACKEND = 'local';
-module.exports.CDN_HOST = '/download';
-module.exports.WITH_THINGPEDIA = 'external';
-module.exports.WITH_LUINET = 'embedded';
-module.exports.THINGPEDIA_URL = 'https://almond-dev.stanford.edu/thingpedia';
-module.exports.ENABLE_PROMETHEUS = true;
-module.exports.PROMETHEUS_ACCESS_TOKEN = 'my-prometheus-access-token';
-module.exports.DISCOURSE_SSO_SECRET = 'd836444a9e4084d5b224a60c208dce14';
 EOF
 
 workdir=`mktemp -t -d almond-nlp-integration-XXXXXX`
@@ -51,6 +39,22 @@ trap on_error ERR INT TERM
 
 oldpwd=`pwd`
 cd $workdir
+
+mkdir -p $workdir/etc/config.d
+export THINGENGINE_CONFIGDIR=$workdir/etc
+NLP_PORT=${NLP_PORT:-8400}
+TRAINING_PORT=${TRAINING_PORT:-8090}
+cat > ${THINGENGINE_CONFIGDIR}/config.yaml <<EOF
+NL_SERVER_URL: "http://127.0.0.1:${NLP_PORT}"
+TRAINING_URL: "http://127.0.0.1:${TRAINING_PORT}"
+FILE_STORAGE_BACKEND: local
+CDN_HOST: /download
+WITH_THINGPEDIA: external
+WITH_LUINET: embedded
+THINGPEDIA_URL: https://almond-dev.stanford.edu/thingpedia
+ENABLE_PROMETHEUS: true
+PROMETHEUS_ACCESS_TOKEN: my-prometheus-access-token
+EOF
 
 node $srcdir/tests/mock-tokenizer.js &
 tokenizerpid=$!

--- a/tests/nlp-integration.sh
+++ b/tests/nlp-integration.sh
@@ -20,9 +20,6 @@ export SECRET_KEY
 
 export THINGENGINE_USE_TOKENIZER=local
 
-cat > $srcdir/secret_config.js <<EOF
-EOF
-
 workdir=`mktemp -t -d almond-nlp-integration-XXXXXX`
 workdir=`realpath $workdir`
 on_error() {
@@ -39,6 +36,9 @@ trap on_error ERR INT TERM
 
 oldpwd=`pwd`
 cd $workdir
+
+# remove stale config files
+rm -f $srcdir/secret_config.js
 
 mkdir -p $workdir/etc/config.d
 export THINGENGINE_CONFIGDIR=$workdir/etc

--- a/tests/thingpedia-integration.sh
+++ b/tests/thingpedia-integration.sh
@@ -29,7 +29,7 @@ cd $workdir
 mkdir -p $workdir/etc/config.d
 export THINGENGINE_CONFIGDIR=$workdir/etc
 PORT=${PORT:-8080}
-cat > ${THINGENGINE_CONFIGDIR}/config.yaml <<EOF
+cat > ${THINGENGINE_CONFIGDIR}/config.d/99-local.yaml <<EOF
 DATABASE_URL: "mysql://thingengine:thingengine@localhost/thingengine_test"
 SERVER_ORIGIN: "http://127.0.0.1:${PORT}"
 FILE_STORAGE_BACKEND: local
@@ -96,7 +96,7 @@ frontendpid=
 wait
 
 # now enable the Stanford pages and run the website again
-cp $srcdir/stanford/config.js $THINGENGINE_CONFIGDIR/config.d/stanford.js
+cp $srcdir/stanford/config.js $THINGENGINE_CONFIGDIR/config.d/00-stanford.js
 
 # the website crawler tests will touch the web almond pages
 # too, so make sure we don't die with 400 or 500 because Almond is off

--- a/tests/thingpedia-integration.sh
+++ b/tests/thingpedia-integration.sh
@@ -26,6 +26,9 @@ trap on_error ERR INT TERM
 oldpwd=`pwd`
 cd $workdir
 
+# remove stale config files
+rm -f $srcdir/secret_config.js
+
 mkdir -p $workdir/etc/config.d
 export THINGENGINE_CONFIGDIR=$workdir/etc
 PORT=${PORT:-8080}

--- a/tests/thingpedia-integration.sh
+++ b/tests/thingpedia-integration.sh
@@ -10,27 +10,6 @@ set -o pipefail
 srcdir=`dirname $0`/..
 srcdir=`realpath $srcdir`
 
-PORT=${PORT:-8080}
-cat > $srcdir/secret_config.js <<EOF
-module.exports.DATABASE_URL="mysql://thingengine:thingengine@localhost/thingengine_test";
-module.exports.SERVER_ORIGIN = 'http://127.0.0.1:${PORT}';
-module.exports.FILE_STORAGE_BACKEND = 'local';
-module.exports.CDN_HOST = '/download';
-module.exports.WITH_THINGPEDIA = 'embedded';
-module.exports.WITH_LUINET = 'embedded';
-module.exports.THINGPEDIA_URL = '/thingpedia';
-module.exports.DOCUMENTATION_URL = '/doc/getting-started.md';
-module.exports.ENABLE_DEVELOPER_PROGRAM = true;
-module.exports.ENABLE_PROMETHEUS = true;
-module.exports.PROMETHEUS_ACCESS_TOKEN = 'my-prometheus-access-token';
-module.exports.DISCOURSE_SSO_SECRET = 'd836444a9e4084d5b224a60c208dce14';
-module.exports.AES_SECRET_KEY = '80bb23f93126074ba01410c8a2278c0c';
-module.exports.JWT_SIGNING_KEY = "not so secret key" ;
-module.exports.SECRET_KEY = "not so secret key";
-module.exports.NL_SERVER_URL = "https://almond-dev.stanford.edu/nnparser";
-module.exports.SUPPORTED_LANGUAGES = ['en-US', 'it-IT', 'zh-CN', 'zh-TW'];
-EOF
-
 workdir=`mktemp -t -d webalmond-integration-XXXXXX`
 workdir=`realpath $workdir`
 on_error() {
@@ -46,6 +25,33 @@ trap on_error ERR INT TERM
 
 oldpwd=`pwd`
 cd $workdir
+
+mkdir -p $workdir/etc/config.d
+export THINGENGINE_CONFIGDIR=$workdir/etc
+PORT=${PORT:-8080}
+cat > ${THINGENGINE_CONFIGDIR}/config.yaml <<EOF
+DATABASE_URL: "mysql://thingengine:thingengine@localhost/thingengine_test"
+SERVER_ORIGIN: "http://127.0.0.1:${PORT}"
+FILE_STORAGE_BACKEND: local
+CDN_HOST: /download
+WITH_THINGPEDIA: embedded
+WITH_LUINET: embedded
+THINGPEDIA_URL: /thingpedia
+DOCUMENTATION_URL: /doc/getting-started.md
+ENABLE_DEVELOPER_PROGRAM: true
+ENABLE_PROMETHEUS: true
+PROMETHEUS_ACCESS_TOKEN: my-prometheus-access-token
+DISCOURSE_SSO_SECRET: d836444a9e4084d5b224a60c208dce14
+AES_SECRET_KEY: 80bb23f93126074ba01410c8a2278c0c
+JWT_SIGNING_KEY: "not so secret key"
+SECRET_KEY: "not so secret key"
+NL_SERVER_URL: "https://almond-dev.stanford.edu/nnparser"
+SUPPORTED_LANGUAGES:
+  - en-US
+  - it-IT
+  - zh-CN
+  - zh-TW
+EOF
 
 # set up download directories
 mkdir -p $workdir/shared/download
@@ -90,27 +96,7 @@ frontendpid=
 wait
 
 # now enable the Stanford pages and run the website again
-cat > $srcdir/secret_config.js <<EOF
-Object.assign(module.exports, require('./stanford/config.js'));
-module.exports.DATABASE_URL="mysql://thingengine:thingengine@localhost/thingengine_test";
-module.exports.SERVER_ORIGIN = 'http://127.0.0.1:${PORT}';
-module.exports.OAUTH_REDIRECT_ORIGIN = module.exports.SERVER_ORIGIN;
-module.exports.FILE_STORAGE_BACKEND = 'local';
-module.exports.CDN_HOST = '/download';
-module.exports.WITH_THINGPEDIA = 'embedded';
-module.exports.WITH_LUINET = 'embedded';
-module.exports.THINGPEDIA_URL = '/thingpedia';
-module.exports.DOCUMENTATION_URL = '/doc/getting-started.md';
-module.exports.ENABLE_DEVELOPER_PROGRAM = true;
-module.exports.ENABLE_PROMETHEUS = true;
-module.exports.PROMETHEUS_ACCESS_TOKEN = 'my-prometheus-access-token';
-module.exports.DISCOURSE_SSO_SECRET = 'd836444a9e4084d5b224a60c208dce14';
-module.exports.AES_SECRET_KEY = '80bb23f93126074ba01410c8a2278c0c';
-module.exports.JWT_SIGNING_KEY = "not so secret key" ;
-module.exports.SECRET_KEY = "not so secret key";
-module.exports.NL_SERVER_URL = "https://almond-dev.stanford.edu/nnparser";
-module.exports.SUPPORTED_LANGUAGES = ['en-US', 'it-IT', 'zh-CN', 'zh-TW'];
-EOF
+cp $srcdir/stanford/config.js $THINGENGINE_CONFIGDIR/config.d/stanford.js
 
 # the website crawler tests will touch the web almond pages
 # too, so make sure we don't die with 400 or 500 because Almond is off

--- a/tests/training-integration.sh
+++ b/tests/training-integration.sh
@@ -12,30 +12,6 @@ srcdir=`realpath $srcdir`
 export THINGENGINE_USE_TOKENIZER=local
 export GENIE_USE_TOKENIZER=local
 
-cat > $srcdir/secret_config.js <<EOF
-module.exports.DATABASE_URL="mysql://thingengine:thingengine@localhost/thingengine_test";
-module.exports.SERVER_ORIGIN = 'http://127.0.0.1:8080';
-module.exports.FILE_STORAGE_BACKEND = 'local';
-module.exports.CDN_HOST = '/download';
-module.exports.WITH_THINGPEDIA = 'embedded';
-module.exports.WITH_LUINET = 'embedded';
-module.exports.THINGPEDIA_URL = '/thingpedia';
-module.exports.DOCUMENTATION_URL = '/doc/getting-started.md';
-module.exports.ENABLE_DEVELOPER_PROGRAM = true;
-module.exports.ENABLE_PROMETHEUS = true;
-module.exports.PROMETHEUS_ACCESS_TOKEN = 'my-prometheus-access-token';
-module.exports.DISCOURSE_SSO_SECRET = 'd836444a9e4084d5b224a60c208dce14';
-module.exports.AES_SECRET_KEY = '80bb23f93126074ba01410c8a2278c0c';
-module.exports.JWT_SIGNING_KEY = "not so secret key" ;
-module.exports.SECRET_KEY = "not so secret key";
-module.exports.NL_SERVER_URL = null;
-module.exports.TRAINING_URL = 'http://127.0.0.1:${PORT}';
-module.exports.TRAINING_ACCESS_TOKEN = 'test-training-access-token';
-module.exports.TRAINING_CONFIG_FILE = './training.conf.json';
-module.exports.TRAINING_MEMORY_USAGE = 1000;
-module.exports.SUPPORTED_LANGUAGES = ['en-US'];
-EOF
-
 workdir=`mktemp -t -d webalmond-integration-XXXXXX`
 workdir=`realpath $workdir`
 on_error() {
@@ -53,6 +29,9 @@ trap on_error ERR INT TERM
 
 oldpwd=`pwd`
 cd $workdir
+
+# remove stale config files
+rm -f $srcdir/secret_config.js
 
 mkdir -p $workdir/etc/config.d
 export THINGENGINE_CONFIGDIR=$workdir/etc

--- a/tests/training-integration.sh
+++ b/tests/training-integration.sh
@@ -12,7 +12,6 @@ srcdir=`realpath $srcdir`
 export THINGENGINE_USE_TOKENIZER=local
 export GENIE_USE_TOKENIZER=local
 
-PORT=${PORT:-8090}
 cat > $srcdir/secret_config.js <<EOF
 module.exports.DATABASE_URL="mysql://thingengine:thingengine@localhost/thingengine_test";
 module.exports.SERVER_ORIGIN = 'http://127.0.0.1:8080';
@@ -54,6 +53,33 @@ trap on_error ERR INT TERM
 
 oldpwd=`pwd`
 cd $workdir
+
+mkdir -p $workdir/etc/config.d
+export THINGENGINE_CONFIGDIR=$workdir/etc
+PORT=${PORT:-8090}
+cat > ${THINGENGINE_CONFIGDIR}/config.yaml <<EOF
+DATABASE_URL: "mysql://thingengine:thingengine@localhost/thingengine_test"
+SERVER_ORIGIN: "http://127.0.0.1:8080"
+FILE_STORAGE_BACKEND: local
+CDN_HOST: /download
+WITH_THINGPEDIA: embedded
+WITH_LUINET: embedded
+THINGPEDIA_URL: /thingpedia
+DOCUMENTATION_URL: /doc/getting-started.md
+ENABLE_DEVELOPER_PROGRAM: true
+ENABLE_PROMETHEUS: true
+PROMETHEUS_ACCESS_TOKEN: my-prometheus-access-token
+DISCOURSE_SSO_SECRET: d836444a9e4084d5b224a60c208dce14
+AES_SECRET_KEY: 80bb23f93126074ba01410c8a2278c0c
+JWT_SIGNING_KEY: "not so secret key"
+SECRET_KEY: "not so secret key"
+NL_SERVER_URL: null
+TRAINING_URL: "http://127.0.0.1:${PORT}"
+TRAINING_ACCESS_TOKEN: test-training-access-token
+TRAINING_CONFIG_FILE: ./training.conf.json
+TRAINING_MEMORY_USAGE: 1000
+SUPPORTED_LANGUAGES: ['en-US']
+EOF
 
 node $srcdir/tests/mock-tokenizer.js &
 tokenizerpid=$!

--- a/util/config_init.js
+++ b/util/config_init.js
@@ -11,21 +11,16 @@
 
 // This file must be imported by all processes before any other module is required
 
+const fs = require('fs');
+const yaml = require('js-yaml');
+const path = require('path');
+
 // base config
 const Config = require('../config');
 
 // load configuration overrides for non-secret data
 try {
     Object.assign(Config, require('../custom_config'));
-} catch(e) {
-    if (e.code !== 'MODULE_NOT_FOUND')
-        throw e;
-    // ignore if there is no file
-}
-
-// load configuration overrides for secret data
-try {
-    Object.assign(Config, require('/etc/almond-cloud/config'));
 } catch(e) {
     if (e.code !== 'MODULE_NOT_FOUND')
         throw e;
@@ -39,6 +34,54 @@ try {
     if (e.code !== 'MODULE_NOT_FOUND')
         throw e;
     // ignore if there is no file
+}
+
+function assign(cfg) {
+    for (let name in cfg) {
+        if (!(name in Config)) {
+            console.error(`WARNING: Unknown configuration key ${name}`);
+            continue;
+        }
+        Config[name] = cfg[name];
+    }
+}
+function tryLoad(pathname) {
+    try {
+        if (pathname.endsWith('.json'))
+            assign(JSON.parse(fs.readFileSync(pathname, 'utf8')));
+        else if (pathname.endsWith('.yaml') || pathname.endsWith('.yml'))
+            assign(yaml.safeLoad(fs.readFileSync(pathname, 'utf8')));
+        else if (pathname.endsWith('.js'))
+            assign(require(pathname));
+        else
+            console.error(`WARNING: Ignored configuration file ${pathname}: unknown file extension`);
+    } catch(e) {
+        if (e.code !== 'EPERM' && e.code !== 'EACCESS' && e.name !== 'SyntaxError')
+            throw e;
+        console.error(`WARNING: Ignored configuration file ${pathname}: ${e.message}`);
+    }
+}
+
+// the new configuration path
+try {
+    const configdir = process.env.THINGENGINE_CONFIGDIR || '/etc/almond-cloud';
+
+    for (let filename of ['config.js', 'config.json', 'config.yaml', 'config.yml']) {
+        const pathname = path.resolve(configdir, filename);
+        if (fs.existsSync(pathname)) {
+            tryLoad(pathname);
+            break;
+        }
+    }
+    const dirpath = path.resolve(configdir, 'config.d');
+    for (let filename of fs.readdirSync(dirpath).sort()) {
+        const pathname = path.resolve(dirpath, filename);
+        tryLoad(pathname);
+    }
+} catch(e) {
+    if (e.code !== 'ENOENT')
+        throw e;
+    // ignore if the directory/file does not exist
 }
 
 if (Config.WITH_THINGPEDIA !== 'embedded' && Config.WITH_THINGPEDIA !== 'external')

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -58,7 +58,7 @@ html
 
     if includefooter
       footer.page-footer.hidden-xs.hidden-sm
-        if Config.USE_STANFORD_BRAND
+        if Config.USE_BRAND == 'stanford'
           include stanford/footer.pug
         else
           include footer.pug


### PR DESCRIPTION
For operational reasons, it makes sense to split the configuration
into multiple files: some configuration keys are secret and some are
not; some are shared between staging & production (like branding)
and some are deployment specific.