### PR TITLE
i18n: ensure the prebound gettext objects have the "locale" property

### DIFF
--- a/util/i18n.js
+++ b/util/i18n.js
@@ -77,6 +77,8 @@ function load() {
 
         // prebind the gt for ease of use, because the usual gettext API is not object-oriented
         const prebound = {
+            locale,
+
             gettext: gt.gettext.bind(gt),
             ngettext: gt.ngettext.bind(gt),
             pgettext: gt.pgettext.bind(gt),


### PR DESCRIPTION
In certain compatibility code paths, ThingTalk retrieves the locale
to use for formatting from the passed gettext object.
If the locale is undefined, it falls back to a generic English-like
locale that is not appropriate for American English.

Fixes https://github.com/stanford-oval/thingtalk/issues/140