### PR TITLE
add tensorboard sync and fixes

### DIFF
--- a/config.js
+++ b/config.js
@@ -399,7 +399,7 @@ module.exports.TRAINING_KUBERNETES_POD_SPEC_OVERRIDE = {};
 module.exports.TRAINING_KUBERNETES_CONTAINER_SPEC_OVERRIDE = {};
 
 /**
-  S3 directory where tensboard events are sycned to during training.
+  Directory in s3:// or file:// URI, where tensboard events are synced to during training.
 */
 module.exports.TENSORBOARD_DIR = null;
 

--- a/config.js
+++ b/config.js
@@ -399,6 +399,11 @@ module.exports.TRAINING_KUBERNETES_POD_SPEC_OVERRIDE = {};
 module.exports.TRAINING_KUBERNETES_CONTAINER_SPEC_OVERRIDE = {};
 
 /**
+  S3 directory where tensboard events are sycned to during training.
+*/
+module.exports.TENSORBOARD_DIR = null;
+
+/**
   URL of documentation.
 
   Set this to a string starting with `/doc` to enable the embedded documentation site. Alternatively,

--- a/doc/almond-config-file-reference.md
+++ b/doc/almond-config-file-reference.md
@@ -392,6 +392,11 @@ Additional fields to add to the Kubernetes Pods created for training.
 
 Default value: `{}`
 
+## TENSORBOARD_DIR
+S3 directory where tensboard events are sycned to during training.
+
+Default value: `null`
+
 ## DOCUMENTATION_URL
 URL of documentation.
 

--- a/doc/almond-config-file-reference.md
+++ b/doc/almond-config-file-reference.md
@@ -393,7 +393,7 @@ Additional fields to add to the Kubernetes Pods created for training.
 Default value: `{}`
 
 ## TENSORBOARD_DIR
-S3 directory where tensboard events are sycned to during training.
+Directory in s3:// or file:// URI, where tensboard events are synced to during training.
 
 Default value: `null`
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM registry.access.redhat.com/ubi7/ubi:latest
 MAINTAINER Thingpedia Admins <thingpedia-admins@lists.stanford.edu>
 
 # install basic tools
-RUN yum -y install git wget gcc gcc-c++ make gettext
+RUN yum -y install git wget gcc gcc-c++ make gettext unzip
 
 # add epel repo
 RUN wget http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm

--- a/docker/Dockerfile.decanlp
+++ b/docker/Dockerfile.decanlp
@@ -6,7 +6,7 @@ MAINTAINER Thingpedia Admins <thingpedia-admins@lists.stanford.edu>
 
 # install basic tools
 USER root
-RUN yum -y install make gettext
+RUN yum -y install make gettext unzip
 
 # install nodejs 10.x and yarn
 RUN curl -sL https://rpm.nodesource.com/setup_10.x | bash -

--- a/nlp/admin.js
+++ b/nlp/admin.js
@@ -57,9 +57,8 @@ router.post('/reload/@:model_tag/:locale', async (req, res, next) => {
         return;
     }
 
-    model.reload().then(() => {
-        res.json({ result: 'ok' });
-    }).catch(next);
+    await model.reload();
+    res.json({ result: 'ok' });
 });
 
 module.exports = router;

--- a/nlp/admin.js
+++ b/nlp/admin.js
@@ -57,8 +57,9 @@ router.post('/reload/@:model_tag/:locale', async (req, res, next) => {
         return;
     }
 
-    await model.reload();
-    res.json({ result: 'ok' });
+    model.reload().then(() => {
+        res.json({ result: 'ok' });
+    }).catch(next);
 });
 
 module.exports = router;

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "nyc": "^14.0.0",
     "parse5": "^5.1.0",
     "planetary.js": "^1.1.3",
+    "proxyquire": "^2.0.0",
     "pug-lint": "^2.4.0",
     "qs": "^6.7.0",
     "selenium-webdriver": "^4.0.0-alpha.3",

--- a/tests/unit/index.js
+++ b/tests/unit/index.js
@@ -15,6 +15,7 @@ async function seq(array) {
 }
 
 seq([
+    ('./test_abstract_fs'),
     ('./test_lock'),
     ('./test_tokenize'),
     ('./test_device_factories'),

--- a/tests/unit/test_abstract_fs.js
+++ b/tests/unit/test_abstract_fs.js
@@ -54,7 +54,7 @@ async function expectCmd(fn, args, want) {
 
 async function testUpload() {
     await expectCmd(afs.upload, ['/tmp/a', afs.resolve('/tmp', 'b')],
-        ['cp -rT /tmp/a /tmp/b']);
+        ['rsync -av /tmp/a /tmp/b']);
 
     await expectCmd(afs.upload, ['/tmp/a', afs.resolve('/tmp', 'a')], []);
 
@@ -63,27 +63,25 @@ async function testUpload() {
 
     await expectCmd(afs.upload, ['/tmp', afs.resolve('s3://bucket/dir', 'a/')],
         ['aws s3 sync /tmp s3://bucket/dir/a/']);
-}
 
-async function testUploadWithExtraArgs() {
-    await expectCmd(afs.uploadWithExtraArgs,
+    await expectCmd(afs.upload,
         ['/tmp/a', afs.resolve('file://host1/tmp', 'b'), '--exclude=*', '--include=*tfevents*'],
         ['rsync -av /tmp/a host1:/tmp/b --exclude=* --include=*tfevents*']);
 
-    await expectCmd(afs.uploadWithExtraArgs,
+    await expectCmd(afs.upload,
         ['/tmp/a', afs.resolve('/tmp', 'b'), '--exclude=*', '--include=*tfevents*'],
         ['rsync -av /tmp/a /tmp/b --exclude=* --include=*tfevents*']);
 
-    await expectCmd(afs.uploadWithExtraArgs,
+    await expectCmd(afs.upload,
         ['/tmp/a', afs.resolve('/tmp', 'a'), '--exclude=*', '--include=*tfevents*'],
         []);
 
-    await expectCmd(afs.uploadWithExtraArgs,
+    await expectCmd(afs.upload,
         ['/tmp', afs.resolve('s3://bucket/dir', 'a/'), '--exclude=*', '--include=*tfevents*'],
         ['aws s3 sync /tmp s3://bucket/dir/a/ --exclude=* --include=*tfevents*']);
 
     const jobid = 15;
-    await expectCmd(afs.uploadWithExtraArgs,
+    await expectCmd(afs.upload,
         ['/home/workdir', afs.resolve('s3://bucket/dir', jobid.toString(), './tag:lang/'), '--exclude=*', '--include=*tfevents*'],
         ['aws s3 sync /home/workdir s3://bucket/dir/15/tag:lang/ --exclude=* --include=*tfevents*']);
 }
@@ -129,7 +127,6 @@ async function testSync() {
 async function main() {
     testResolve();
     await testUpload();
-    await testUploadWithExtraArgs();
     await testSync();
 }
 module.exports = main;

--- a/tests/unit/test_abstract_fs.js
+++ b/tests/unit/test_abstract_fs.js
@@ -99,6 +99,9 @@ async function testSync() {
     await expectCmd(afs.sync, [afs.resolve('/tmp'), afs.resolve('s3://bucket/dir', 'a/')],
         ['aws s3 sync /tmp s3://bucket/dir/a/']);
 
+    await expectCmd(afs.sync, [afs.resolve('s3://bucket/dir', 'b/'), afs.resolve('s3://bucket/dir', 'a/')],
+        ['aws s3 sync s3://bucket/dir/b/ s3://bucket/dir/a/']);
+
     await expectCmd(afs.sync, [afs.resolve('s3://bucket/dir', 'a/'), afs.resolve('/workdir/a')],
         ['aws s3 sync s3://bucket/dir/a/ /var/tmp/x',
          'rsync -av /var/tmp/x /workdir/a',

--- a/tests/unit/test_abstract_fs.js
+++ b/tests/unit/test_abstract_fs.js
@@ -1,0 +1,101 @@
+// -*- mode: js; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of ThingEngine
+//
+// Copyright 2019 The Board of Trustees of the Leland Stanford Junior University
+//
+// Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
+//
+// See COPYING for details
+'use strict';
+
+const assert = require('assert');
+const proxyquire = require('proxyquire')
+
+const cmdStub = {
+    lastCmd: null,
+    exec: function(file, argv) {
+        this.lastCmd = [file, ...argv];
+    }
+}
+
+const afs = proxyquire('../../util/abstract_fs', {'./command': cmdStub} );
+
+function testResolve() {
+    assert.strictEqual(afs.resolve('file://foo', 'bar').toString(), 'file://foo//bar');
+    assert.strictEqual(afs.resolve('/foo', 'bar').toString(), 'file:///foo/bar');
+    assert.strictEqual(afs.resolve('file:///foo', 'bar').toString(), 'file:///foo/bar');
+
+    assert.strictEqual(afs.resolve('s3://bucket/dir', 'a', 'b'), 's3://bucket/dir/a/b');
+    assert.strictEqual(afs.resolve('s3://bucket/dir', '/a/b'), 's3:///a/b');
+    assert.strictEqual(afs.resolve('s3://bucket/dir', 'tag:lang'), 'tag:lang');
+    assert.strictEqual(afs.resolve('s3://bucket/dir', './tag:lang/'), 's3://bucket/dir/tag:lang/');
+    assert.strictEqual(afs.resolve('s3://bucket/dir', './tag:lang/./'), 's3://bucket/dir/tag:lang/');
+    assert.strictEqual(afs.resolve('s3://bucket/dir', './tag:lang//'), 's3://bucket/dir/tag:lang//');
+}
+
+
+async function expectCmd(fn, args, want) {
+    cmdStub.lastCmd = null;
+    await fn(...args);
+    try {
+    	assert.deepEqual(cmdStub.lastCmd, want, `${fn.name}(${args})`); 
+    } catch (err) {
+        err.message = `${err}\n   got: ${err.actual}\n  want: ${err.expected}`
+        throw err
+    }
+}
+
+async function testUpload() {
+    await expectCmd(afs.upload, ['/tmp/a', afs.resolve('/tmp', 'b')],
+        ['cp', '-rT', '/tmp/a', '/tmp/b']);
+
+    await expectCmd(afs.upload, ['/tmp/a', afs.resolve('/tmp', 'b')],
+        ['cp', '-rT', '/tmp/a', '/tmp/b']);
+
+    await expectCmd(afs.upload, ['/tmp/a', afs.resolve('/tmp', 'b')],
+        ['cp', '-rT', '/tmp/a', '/tmp/b']);
+
+    await expectCmd(afs.upload, ['/tmp/a', afs.resolve('/tmp', 'a')], null);
+
+    await expectCmd(afs.upload, ['/tmp/a', afs.resolve('file://host1/tmp', 'b')],
+        ['rsync', '-av', '/tmp/a', 'host1:/tmp/b']);
+
+    await expectCmd(afs.upload, ['/tmp', afs.resolve('s3://bucket/dir', 'a/')],
+        ['aws', 's3', 'sync', '/tmp', 's3://bucket/dir/a/']);
+}
+
+async function testUploadWithExtraArgs() {
+    await expectCmd(afs.uploadWithExtraArgs,
+        ['/tmp/a', afs.resolve('file://host1/tmp', 'b'), '--exclude=*', '--include=*tfevents*'],
+        ['rsync', '-av', '/tmp/a', 'host1:/tmp/b', '--exclude=*', '--include=*tfevents*']);
+
+    await expectCmd(afs.uploadWithExtraArgs,
+        ['/tmp/a', afs.resolve('/tmp', 'b'), '--exclude=*', '--include=*tfevents*'],
+        ['rsync', '-av', '/tmp/a', '/tmp/b', '--exclude=*', '--include=*tfevents*']);
+
+    await expectCmd(afs.uploadWithExtraArgs,
+        ['/tmp/a', afs.resolve('/tmp', 'a'), '--exclude=*', '--include=*tfevents*'],
+         null);
+
+    await expectCmd(afs.uploadWithExtraArgs,
+        ['/tmp', afs.resolve('s3://bucket/dir', 'a/'), '--exclude=*', '--include=*tfevents*'],
+        ['aws', 's3', 'sync', '/tmp', 's3://bucket/dir/a/', '--exclude=*', '--include=*tfevents*']);
+
+    const jobid = 15;
+    await expectCmd(afs.uploadWithExtraArgs,
+        ['/home/workdir', afs.resolve('s3://bucket/dir', jobid.toString(), './tag:lang/'), '--exclude=*', '--include=*tfevents*'],
+        ['aws', 's3', 'sync', '/home/workdir', 's3://bucket/dir/15/tag:lang/', '--exclude=*', '--include=*tfevents*']);
+
+
+}
+
+
+async function main() {
+    testResolve();
+    await testUpload();
+    await testUploadWithExtraArgs();
+}
+module.exports = main;
+if (!module.parent)
+    main();

--- a/tests/unit/test_abstract_fs.js
+++ b/tests/unit/test_abstract_fs.js
@@ -119,8 +119,8 @@ async function testSync() {
 
     const jobid = 15;
     await expectCmd(afs.sync,
-        ['/home/workdir', afs.resolve('s3://bucket/dir', jobid.toString(), './tag:lang/'), '--exclude=* --include=*tfevents*'],
-        ['aws s3 sync /home/workdir s3://bucket/dir/15/tag:lang/ --exclude=* --include=*tfevents*']);
+        ['/var/tmp/workdir', afs.resolve('s3://bucket/dir', jobid.toString(), './tag:lang/'), '--exclude=* --include=*tfevents*'],
+        ['aws s3 sync /var/tmp/workdir s3://bucket/dir/15/tag:lang/ --exclude=* --include=*tfevents*']);
 }
 
 

--- a/training/daemon.js
+++ b/training/daemon.js
@@ -43,7 +43,7 @@ class TrainingDaemon {
             for (let job of existing) {
                 job.status = 'error';
                 job.error = 'Master process failed';
-                await this._recordJobCompletion(job);
+                await this._recordJobCompletion(dbClient, job);
             }
         });
 
@@ -227,7 +227,7 @@ Check the logs for further information.`
             } else {
                 job.status = 'error';
                 job.error = 'Killed';
-                await this._recordJobCompletion(job);
+                await this._recordJobCompletion(dbClient, job);
             }
         });
     }

--- a/training/tasks/prepare-training-set.js
+++ b/training/tasks/prepare-training-set.js
@@ -67,10 +67,9 @@ class TypecheckStream extends Stream.Transform {
             return;
         }
 
-        const entities = Genie.Utils.makeDummyEntities(ex.preprocessed);
-        const program = ThingTalk.NNSyntax.fromNN(ex.target_code.split(' '), entities);
-
         try {
+            const entities = Genie.Utils.makeDummyEntities(ex.preprocessed);
+            const program = ThingTalk.NNSyntax.fromNN(ex.target_code.split(' '), entities);
             await program.typecheck(this._schemas);
             this.push(ex);
             return;

--- a/training/tasks/train.js
+++ b/training/tasks/train.js
@@ -50,7 +50,7 @@ module.exports = async function main(task, argv) {
     genieJob.on('progress', async (value) => {
         task.setProgress(value);
         if (Config.TENSORBOARD_DIR) {
-              await AbstractFS.uploadWithExtraArgs(
+              await AbstractFS.sync(
                   workdir,
                   AbstractFS.resolve(Config.TENSORBOARD_DIR, task.jobId.toString(), `./${task.info.model_tag}:${task.language}/`),
                  '--exclude=*', '--include=*tfevents*');

--- a/training/tasks/train.js
+++ b/training/tasks/train.js
@@ -65,5 +65,6 @@ module.exports = async function main(task, argv) {
     if (!task.killed) {
         await task.setMetrics(genieJob.metrics);
         await AbstractFS.upload(outputdir, AbstractFS.resolve(task.jobDir, 'output'));
+        await AbstractFS.removeTemporary(jobdir);
     }
 };

--- a/training/tasks/train.js
+++ b/training/tasks/train.js
@@ -16,6 +16,7 @@ const fs = require('fs');
 const Genie = require('genie-toolkit');
 
 const AbstractFS = require('../../util/abstract_fs');
+const cmd = require('../../util/command');
 
 const Config = require('../../config');
 
@@ -50,6 +51,13 @@ module.exports = async function main(task, argv) {
     const genieJob = Genie.Training.createJob(options);
     genieJob.on('progress', (value) => {
         task.setProgress(value);
+	if (Config.TENSORBOARD_DIR) {
+            cmd.exec('aws', [ 's3', 'sync',
+                 workdir, `${Config.TENSORBOARD_DIR}/${task.jobId}/${task.info.model_tag}:${task.language}/`,
+                 '--exclude="*"',
+                 '--include="*tfevents*"'
+            ]);
+        }
     });
     task.on('killed', () => {
         genieJob.kill();

--- a/util/abstract_fs.js
+++ b/util/abstract_fs.js
@@ -56,7 +56,7 @@ const _backends = {
 
         async uploadWithExtraArgs(localdir, url, ...extraArgs) {
             const args = ['s3', 'sync', localdir, 's3://' + url.hostname + url.pathname];
-            if (extraArgs) args.push(...extraArgs);
+            if (extraArgs.length > 0) args.push(...extraArgs);
             await cmd.exec('aws', args);
         },
 
@@ -69,7 +69,7 @@ const _backends = {
                 's3://' + url1.hostname + url1.pathname,
                 's3://' + url2.hostname + url2.pathname,
             ];
-            if (extraArgs) args.push(...extraArgs);
+            if (extraArgs.length > 0) args.push(...extraArgs);
             return cmd.exec('aws', args);
         },
 
@@ -127,7 +127,7 @@ const _backends = {
                 hostname = url.hostname + ':';
             }
             const args = ['-av', localdir, `${hostname}${url.pathname}`];
-            if (extraArgs) args.push(...extraArgs);
+            if (extraArgs.length > 0) args.push(...extraArgs);
             await cmd.exec('rsync', args);
         },
 
@@ -150,7 +150,7 @@ const _backends = {
                 url1.hostname ? `${url1.hostname}:${url1.pathname}` : url1.pathname,
                 url2.hostname ? `${url2.hostname}:${url2.pathname}` : url2.pathname,
             ];
-            if (extraArgs) args.push(...extraArgs);
+            if (extraArgs.length > 0) args.push(...extraArgs);
             return cmd.exec('rsync', args);
         },
 

--- a/util/abstract_fs.js
+++ b/util/abstract_fs.js
@@ -63,7 +63,7 @@ const _backends = {
         },
 
         async sync(url1, url2, ...extraArgs) {
-            const args = ['s3',
+            const args = ['s3', 'sync',
                 's3://' + url1.hostname + url1.pathname,
                 's3://' + url2.hostname + url2.pathname,
             ];

--- a/util/abstract_fs.js
+++ b/util/abstract_fs.js
@@ -77,12 +77,19 @@ const _backends = {
 
             const s3 = new AWS.S3();
             const stream = new Stream.PassThrough();
-            const upload = s3.upload({
+            const key = url.pathname.startsWith('/') ? url.pathname.substring(1) : url.pathname;
+            s3.upload({
                 Bucket: url.hostname,
-                Key: url.pathname,
+                Key: key,
                 Body: stream,
+            },(err, data) => {
+               if (err) {
+                  console.log('upload error:', err);
+                  stream.emit('error', err);
+                  return;
+               }
+               console.log('upload success:', data);
             });
-            upload.on('error', (e) => stream.emit('error', e));
 
             return stream;
         }

--- a/util/abstract_fs.js
+++ b/util/abstract_fs.js
@@ -214,11 +214,12 @@ module.exports = {
             await backend1.sync(parsed1, parsed2, ...extraArgs);
             return;
         }
-
         // download to a temporary directory, then upload
         const tmpdir = await backend1.download(parsed1, ...extraArgs);
         await backend2.upload(tmpdir, parsed2, ...extraArgs);
-        await module.exports.removeTemporary(tmpdir);
+        // tmpdir is not created for local file
+        if (parsed1.protocol !== 'file:')
+            await module.exports.removeTemporary(tmpdir);
     },
 
     createWriteStream(url) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2515,6 +2515,14 @@ file-uri-to-path@1.0.0:
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
   integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
+fill-keys@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/fill-keys/-/fill-keys-1.0.2.tgz#9a8fa36f4e8ad634e3bf6b4f3c8882551452eb20"
+  integrity sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=
+  dependencies:
+    is-object "~1.0.1"
+    merge-descriptors "~1.0.0"
+
 fill-range@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-4.0.0.tgz#d544811d428f98eb06a63dc402d2403c328c38f7"
@@ -3448,6 +3456,11 @@ is-number@^3.0.0:
   dependencies:
     kind-of "^3.0.2"
 
+is-object@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.1.tgz#8952688c5ec2ffd6b03ecc85e769e02903083470"
+  integrity sha1-iVJojF7C/9awPsyF52ngKQMINHA=
+
 is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
@@ -4114,7 +4127,7 @@ media-typer@0.3.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
 
-merge-descriptors@1.0.1:
+merge-descriptors@1.0.1, merge-descriptors@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
   integrity sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=
@@ -4300,6 +4313,11 @@ module-deps@^6.0.0:
     subarg "^1.0.0"
     through2 "^2.0.0"
     xtend "^4.0.0"
+
+module-not-found-error@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/module-not-found-error/-/module-not-found-error-1.0.1.tgz#cf8b4ff4f29640674d6cdd02b0e3bc523c2bbdc0"
+  integrity sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=
 
 moment-timezone@^0.5.23:
   version "0.5.26"
@@ -5182,6 +5200,15 @@ proxy-addr@~2.0.5:
     forwarded "~0.1.2"
     ipaddr.js "1.9.0"
 
+proxyquire@^2.0.0:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/proxyquire/-/proxyquire-2.1.3.tgz#2049a7eefa10a9a953346a18e54aab2b4268df39"
+  integrity sha512-BQWfCqYM+QINd+yawJz23tbBM40VIGXOdDw3X344KcclI/gtBbdWF6SlQ4nK/bYhF9d27KYug9WzljHC6B9Ysg==
+  dependencies:
+    fill-keys "^1.0.2"
+    module-not-found-error "^1.0.1"
+    resolve "^1.11.1"
+
 prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
@@ -5588,7 +5615,7 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@^1.1.4, resolve@^1.1.5, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.4.0:
+resolve@^1.1.4, resolve@^1.1.5, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.11.1, resolve@^1.4.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
   integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==


### PR DESCRIPTION
Sync tensorboard events when training progress is updated.   Tensorboard can then point to the S3 directory  to access the metrics.   ModelTag and language are added to the path for readability.

I didn't do the sync after eval, which will require to parse decanlp outputs. We can look into detecting eval events if needed in the future.