### PR TITLE
Fix training of custom models

### DIFF
--- a/util/training_server.js
+++ b/util/training_server.js
@@ -108,7 +108,7 @@ class TrainingServer {
 
         let auth = Config.TRAINING_ACCESS_TOKEN ? `Bearer ${Config.TRAINING_ACCESS_TOKEN}` : null;
         return Tp.Helpers.Http.post(Config.TRAINING_URL + '/jobs/create', JSON.stringify({
-            language, forDevices: [], modelTag, jobType,
+            language, forDevices: null, modelTag, jobType,
         }), { auth: auth, dataContentType: 'application/json' }).then((response) => {
             let parsed = JSON.parse(response);
             console.log('Successfully started training job ' + parsed.id);


### PR DESCRIPTION
The training API accepts "null" to mean all devices, or a
*non-empty* array to mean a specific set of devices.
When training a custom model, we don't refer to a specific device.

Fixes #474