### PR TITLE
classifier: use torch 1.1.0

### DIFF
--- a/nlp/python_classifier/requirements.txt
+++ b/nlp/python_classifier/requirements.txt
@@ -1,4 +1,4 @@
-torch >= 1.0.0
+torch == 1.1.0
 pytorch_transformers==1.2.0
 tensorboardX
 tqdm


### PR DESCRIPTION
pytorch-transformers works with later torch too, but decanlp doesn't,
so we end up installing torch twice in tests, which is annoying