### PR TITLE
Works around quirks for k8s watch

### DIFF
--- a/config.js
+++ b/config.js
@@ -427,6 +427,11 @@ module.exports.TRAINING_KUBERNETES_POD_SPEC_OVERRIDE = {};
 module.exports.TRAINING_KUBERNETES_CONTAINER_SPEC_OVERRIDE = {};
 
 /**
+  Number of tries to watch k8s job status. Setting to a negative number, will try indefinitely.
+*/
+module.exports.TRAINING_WATCH_NUM_TRIES = 5;
+
+/**
   Directory in s3:// or file:// URI, where tensorboard events are synced to during training.
 */
 module.exports.TENSORBOARD_DIR = null;

--- a/config.js
+++ b/config.js
@@ -427,7 +427,7 @@ module.exports.TRAINING_KUBERNETES_POD_SPEC_OVERRIDE = {};
 module.exports.TRAINING_KUBERNETES_CONTAINER_SPEC_OVERRIDE = {};
 
 /**
-  Number of tries to watch k8s job status. Setting to a negative number, will try indefinitely.
+  Number of tries to watch k8s job status. Setting to a negative number will try indefinitely.
 */
 module.exports.TRAINING_WATCH_NUM_TRIES = 5;
 

--- a/doc/almond-config-file-reference.md
+++ b/doc/almond-config-file-reference.md
@@ -420,6 +420,11 @@ Additional fields to add to the Kubernetes Pods created for training.
 
 Default value: `{}`
 
+## TRAINING_WATCH_NUM_TRIES
+Number of tries to watch k8s job status. Setting to a negative number, will try indefinitely.
+
+Default value: `5`
+
 ## TENSORBOARD_DIR
 Directory in s3:// or file:// URI, where tensorboard events are synced to during training.
 

--- a/doc/almond-config-file-reference.md
+++ b/doc/almond-config-file-reference.md
@@ -421,7 +421,7 @@ Additional fields to add to the Kubernetes Pods created for training.
 Default value: `{}`
 
 ## TRAINING_WATCH_NUM_TRIES
-Number of tries to watch k8s job status. Setting to a negative number, will try indefinitely.
+Number of tries to watch k8s job status. Setting to a negative number will try indefinitely.
 
 Default value: `5`
 

--- a/training/backends/kubernetes.js
+++ b/training/backends/kubernetes.js
@@ -30,7 +30,7 @@ const watcher = new class JobWatcher extends Tp.Helpers.RefCounted {
 
     watch(jobName, callbacks) {
         this._watchedJobs.set(jobName, callbacks);
-        // Number of tries to watch job status. Setting to a negative number, will try indefinitely.
+        // Number of tries to watch job status. Setting to a negative number will try indefinitely.
         this._numTriesLeft = parseInt(Config.TRAINING_WATCH_NUM_TRIES | 5);
     }
 
@@ -48,7 +48,7 @@ const watcher = new class JobWatcher extends Tp.Helpers.RefCounted {
     }
 
     async _watchJobs() {
-        if (this._numriesLeft === 0) {
+        if (this._numTriesLeft === 0) {
             console.log('Num tries exceeded');
             for (let [jobName, callback] of this._watchedJobs.entries()) {
                 console.error('failed to watch job', jobName);
@@ -59,7 +59,7 @@ const watcher = new class JobWatcher extends Tp.Helpers.RefCounted {
         console.log('Watching num jobs:', this._watchedJobs.size,  'with num tries left:', this._numTriesLeft);
         let currentJobs;
         try {
-           currentJobs = (await k8sApi.listNamespacedJob(Config.TRAINING_KUBERNETES_NAMESPACE,
+            currentJobs = (await k8sApi.listNamespacedJob(Config.TRAINING_KUBERNETES_NAMESPACE,
                 false /* includeUninitialized */,
                 false /* pretty */,
                 undefined /* _continue */,

--- a/training/backends/kubernetes.js
+++ b/training/backends/kubernetes.js
@@ -31,7 +31,7 @@ const watcher = new class JobWatcher extends Tp.Helpers.RefCounted {
     watch(jobName, callbacks) {
         this._watchedJobs.set(jobName, callbacks);
         // Number of tries to watch job status. Setting to a negative number will try indefinitely.
-        this._numTriesLeft = parseInt(Config.TRAINING_WATCH_NUM_TRIES | 5);
+        this._numTriesLeft = parseInt(Config.TRAINING_WATCH_NUM_TRIES || 5);
     }
 
     _computeLabelSelector() {

--- a/training/backends/kubernetes.js
+++ b/training/backends/kubernetes.js
@@ -30,6 +30,8 @@ const watcher = new class JobWatcher extends Tp.Helpers.RefCounted {
 
     watch(jobName, callbacks) {
         this._watchedJobs.set(jobName, callbacks);
+        // Number of tries to watch job status. Setting to a negative number, will try indefinitely.
+        this._numTriesLeft = parseInt(Config.TRAINING_WATCH_NUM_TRIES | 5);
     }
 
     _computeLabelSelector() {
@@ -42,9 +44,22 @@ const watcher = new class JobWatcher extends Tp.Helpers.RefCounted {
     }
 
     async _doOpen() {
+        this._watchJobs();
+    }
+
+    async _watchJobs() {
+        if (this._numriesLeft === 0) {
+            console.log('Num tries exceeded');
+            for (let [jobName, callback] of this._watchedJobs.entries()) {
+                console.error('failed to watch job', jobName);
+                callback.reject(new Error('Kubernetes failed to watch ' + jobName));
+            }
+            return;
+        }
+        console.log('Watching num jobs:', this._watchedJobs.size,  'with num tries left:', this._numTriesLeft);
         let currentJobs;
         try {
-            currentJobs = (await k8sApi.listNamespacedJob(Config.TRAINING_KUBERNETES_NAMESPACE,
+           currentJobs = (await k8sApi.listNamespacedJob(Config.TRAINING_KUBERNETES_NAMESPACE,
                 false /* includeUninitialized */,
                 false /* pretty */,
                 undefined /* _continue */,
@@ -53,15 +68,21 @@ const watcher = new class JobWatcher extends Tp.Helpers.RefCounted {
         } catch(err) {
             throw new Error('Failed to list Kubernetes jobs:' +  JSON.stringify(err));
         }
-
         for (let job of currentJobs.items)
             this._processJob(job);
         this._resourceVersion = currentJobs.metadata.resourceVersion;
+        if (this._watchedJobs.size === 0) {
+            console.log('Finished processing all jobs from list jobs');
+            return;
+        }
 
         const url = `/apis/batch/v1/namespaces/${Config.TRAINING_KUBERNETES_NAMESPACE}/jobs`;
         this._req = this._watcher.watch(url, {
             resourceVersion: this._resourceVersion,
-            labelSelector: this._computeLabelSelector()
+            labelSelector: this._computeLabelSelector(),
+            // Setting timeout to a large number (7 days). Even so, we may still see occasional
+            // server connection drops. So retrying is necessary.
+            timeoutSeconds: 604800
         }, (type, k8sJob) => {
             if (type !== 'ADDED' && type !== 'MODIFIED' && type !== 'DELETED') {
                 console.log('Ignored job state change', type, 'for', k8sJob.metadata.name);
@@ -70,10 +91,13 @@ const watcher = new class JobWatcher extends Tp.Helpers.RefCounted {
             this._processJob(k8sJob, type);
         }, (err) => {
             console.error('watch jobs error:', err);
+            if (this._watchedJobs.size > 0) {
+                this._numTriesLeft--;
+                this._watchJobs();
+            }
         });
     }
     
-
     _processJob(k8sJob, type) {
         const jobName = k8sJob.metadata.name;
         console.log('processing job', jobName);


### PR DESCRIPTION
Turns out there is a default server timeout of 30 minutes in k8s watch api.  This PR sets the timeout to a large number (7 days).   Even so, we may occasionally see server connection drops.  To make it more robust, also added retry mechanism.

Fixes #512 