### PR TITLE
fix docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi7/ubi:latest
+FROM registry.access.redhat.com/ubi7/ubi:7.7-140
 
 MAINTAINER Thingpedia Admins <thingpedia-admins@lists.stanford.edu>
 


### PR DESCRIPTION
ubi7:latest  broke python36 dependency. Pin to last good UBI version 7.7-140.