### PR TITLE
training: fix preparing the training set

### DIFF
--- a/training/tasks/prepare-training-set.js
+++ b/training/tasks/prepare-training-set.js
@@ -306,7 +306,17 @@ class DatasetGenerator {
     async run() {
         await db.withTransaction(async (dbClient) => {
             this._dbClient = dbClient;
-            return this._transaction();
+
+            const timeout = setInterval(() => {
+                this._dbClient.ping((err) => {
+                    if (err)
+                        console.error(`Ignored error in PING to database: ` + err.message);
+                });
+            }, 60000);
+
+            await this._transaction();
+
+            clearInterval(timeout);
         }, 'repeatable read', 'read only');
     }
 }

--- a/training/tasks/prepare-training-set.js
+++ b/training/tasks/prepare-training-set.js
@@ -314,9 +314,11 @@ class DatasetGenerator {
                 });
             }, 60000);
 
-            await this._transaction();
-
-            clearInterval(timeout);
+            try {
+                await this._transaction();
+            } finally {
+                clearInterval(timeout);
+            }
         }, 'repeatable read', 'read only');
     }
 }


### PR DESCRIPTION
The whole prepare-training-set task is run inside a single database
transaction, to ensure a consistent snapshot of Thingpedia is used.
At the same time, most of the queries are run at the beginning
of the transaction only. This can cause the server to close
the connection due to inactivity, which later would cause us
to fail when committing the transaction.

Fixes #517