### PR TITLE
Add new Web Almond APIs for stateless conversation and device configuration

### DIFF
--- a/almond/assistant.js
+++ b/almond/assistant.js
@@ -121,14 +121,19 @@ module.exports = class Assistant extends events.EventEmitter {
         });
         const delegate = conversation._delegate;
 
-        if (command.type === 'command')
+        switch (command.type) {
+        case 'command':
             await conversation.handleCommand(command.text);
-        else if (command.type === 'parsed')
+            break;
+        case 'parsed':
             await conversation.handleParsedCommand(command.json);
-        else if (command.type === 'tt')
+            break;
+        case 'tt':
             await conversation.handleThingTalk(command.code);
-        else
+            break;
+        default:
             throw new Error('Invalid command type ' + command.type);
+        }
 
         const result = delegate.flush();
         result.conversationId = conversation.id;

--- a/doc/my-api.md
+++ b/doc/my-api.md
@@ -198,6 +198,47 @@ is closed.
 
 For details on how to control a conversation with Almond, see the [Almond Dialog API Reference](/doc/almond-dialog-api-reference.md).
 
+## Endpoint: /converse
+
+Execute a single turn of an Almond conversation. This is the REST equivalent of `/conversation`,
+and is provided for clients who cannot use Web Sockets.
+
+Method: POST  
+Scope: `user-exec-commands`
+
+```
+POST /me/api/apps/create
+Authorization: Bearer XYZIEOSKLQOW9283472KLW
+Content-Type: application/json
+
+{
+  "command": {
+    "type":"command",
+    "text":"what time is it?"
+  }
+}
+
+HTTP/1.1 200 Ok
+Content-Type: application/json
+
+{
+    "conversationId": "stateless-...",
+    "askSpecial": null,
+    "messages": [
+      { "type": "text", "text": "Current time is 6:24:57 PM PDT.", "icon": "org.thingpedia.builtin.thingengine.builtin" }
+    ]
+}
+```
+
+The request body should contain a single message from the user to Almond. The response
+body will contain a `conversationId` token that can be passed to subsequent calls to
+preserve state, and a list of messages from Almond. For details on the format of messages
+from the user and from Almond, see the [Almond Dialog API Reference](/doc/almond-dialog-api-reference.md).
+
+NOTE: after 5 minutes of inactivity, the conversationId is reset and the state of the conversation
+is lost. You can send a message containing a `bookkeeping(wakeup);` ThingTalk command to keep
+the conversation alive.
+
 ## Endpoint: /apps/create
 
 Execute a single ThingTalk command.

--- a/doc/my-api.md
+++ b/doc/my-api.md
@@ -330,6 +330,50 @@ Use this API to retrieve the unique ID, name, description, and kind of the confi
 The API returns a list of JSON objects, one for each device. You should not assume that the list
 is sorted in any particular order.
 
+## Endpoint: /devices/create
+
+Configure a new Thingpedia device.
+
+Method: POST  
+Scope: `user-exec-command`
+
+```
+GET /me/api/devices/create
+Authorization: Bearer XYZIEOSKLQOW9283472KLW
+Content-Type: application/json
+
+{
+"kind": "io.home-assistant",
+"hassUrl": "..."
+"accessToken": "...",
+"refreshToken": "...",
+"accessTokenExpires": "...".
+}
+
+HTTP/1.1 200 Ok
+Content-Type: application/json
+
+{
+  "uniqueId": "io.home-assistant-...",
+  "name": "Home Assistant",
+  "description": "This is your Home Assistant Gateway.",
+  "kind": "io.home-assistant",
+  "ownerTier": "global",
+}
+```
+
+This API provides low-level access to configure new devices, by-passing the normal configuration
+mechanism. One use-case for this API are API users that also have their own device in Thingpedia, and can generate
+access tokens for themselves without involving the user.
+The parameters are as defined by the device itself, with the exception of the `kind` parameter
+which identifies the class in Thingpedia. The API returns the same object that
+would be returned by `/devices/list`.
+
+NOTE: if you want to configure a device for which you do not have the correct access tokens, you should
+use one of the APIs that execute ThingTalk (`/converse` or `/apps/create`) and execute a program
+that invokes the `@org.thingpedia.builtin.thingengine.builtin.configure` action. The program will
+request any information from the user as necessary. 
+
 ## Endpoint: /apps/list
 
 List active long-running ThingTalk commands.

--- a/doc/my-api.md
+++ b/doc/my-api.md
@@ -207,7 +207,7 @@ Method: POST
 Scope: `user-exec-commands`
 
 ```
-POST /me/api/apps/create
+POST /me/api/converse
 Authorization: Bearer XYZIEOSKLQOW9283472KLW
 Content-Type: application/json
 
@@ -338,7 +338,7 @@ Method: POST
 Scope: `user-exec-command`
 
 ```
-GET /me/api/devices/create
+POST /me/api/devices/create
 Authorization: Bearer XYZIEOSKLQOW9283472KLW
 Content-Type: application/json
 

--- a/routes/my_api.js
+++ b/routes/my_api.js
@@ -130,6 +130,22 @@ router.get('/devices/list', user.requireScope('user-read'), (req, res, next) => 
     }).catch(next);
 });
 
+router.post('/devices/create', user.requireScope('user-exec-command'), iv.validatePOST({ kind: 'string' }, { accept: 'json', json: true }), (req, res, next) => {
+    for (let key in req.body) {
+        if (typeof req.body[key] !== 'string') {
+            iv.failKey(req, res, key, { json: true });
+            return;
+        }
+    }
+
+    EngineManager.get().getEngine(req.user.id).then(async (engine) => {
+        const devices = engine.devices;
+
+        const device = await devices.addSerialized(req.body);
+        res.json(await describeDevice(device, req));
+    }).catch(next);
+});
+
 function describeApp(app) {
     return Promise.all([app.uniqueId, app.description, app.error, app.code, app.icon])
         .then(([uniqueId, description, error, code, icon]) => ({

--- a/tests/test_website_selenium.js
+++ b/tests/test_website_selenium.js
@@ -164,7 +164,7 @@ async function skipDataCollectionConfirmation(driver) {
 }
 
 async function testMyConversation(driver) {
-    await login(driver, 'bob', '12345678');
+    await login(driver, 'david', '12345678');
 
     await skipDataCollectionConfirmation(driver);
 

--- a/tests/website/test_my_api.js
+++ b/tests/website/test_my_api.js
@@ -211,6 +211,9 @@ async function testMyApiDevices(auth) {
         ownerTier: 'global' },
     ]);
 
+    if (Config.WITH_THINGPEDIA === 'embedded')
+        return;
+
     const createResult = JSON.parse(await request('/me/api/devices/create', 'POST', JSON.stringify({
         kind: 'com.xkcd',
     }), { auth, dataContentType: 'application/json' }));

--- a/tests/website/test_my_api.js
+++ b/tests/website/test_my_api.js
@@ -184,7 +184,7 @@ async function testMyApiDeleteApp(auth, uniqueId) {
     await assertHttpError(request('/me/api/apps/delete/uuid-invalid', 'POST', '', { auth }), 404);
 }
 
-async function testMyApiListDevices(auth) {
+async function testMyApiDevices(auth) {
     const listResult = JSON.parse(await request('/me/api/devices/list', 'GET', null, { auth }));
     console.log(listResult);
     assert.deepStrictEqual(listResult, [
@@ -209,6 +209,48 @@ async function testMyApiListDevices(auth) {
         description: 'Test Almond in various ways',
         kind: 'org.thingpedia.builtin.test',
         ownerTier: 'global' },
+    ]);
+
+    const createResult = JSON.parse(await request('/me/api/devices/create', 'POST', JSON.stringify({
+        kind: 'com.xkcd',
+    }), { auth, dataContentType: 'application/json' }));
+
+    assert.deepStrictEqual(createResult, {
+        uniqueId: 'com.xkcd',
+        name: 'XKCD',
+        description: 'A webcomic of romance, sarcasm, math, and language.',
+        kind: 'com.xkcd',
+        ownerTier: 'global'
+    });
+
+    const listResult2 = JSON.parse(await request('/me/api/devices/list', 'GET', null, { auth }));
+    assert.deepStrictEqual(listResult2, [
+      { uniqueId: 'thingengine-own-cloud',
+        name: 'Almond cloud ()',
+        description: 'This is one of your own Almond apps.',
+        kind: 'org.thingpedia.builtin.thingengine',
+        ownerTier: 'cloud' },
+      { uniqueId: 'thingengine-own-global',
+        name: 'Miscellaneous Interfaces',
+        description: 'Time, randomness and other non-device specific things.',
+        kind: 'org.thingpedia.builtin.thingengine.builtin',
+        ownerTier: 'global' },
+      { uniqueId: 'org.thingpedia.builtin.thingengine.remote',
+        name: 'Remote Almond',
+        description:
+         'A proxy device for a Almond owned by a different user. This device is created and managed automatically by the system.',
+        kind: 'org.thingpedia.builtin.thingengine.remote',
+        ownerTier: 'global' },
+      { uniqueId: 'org.thingpedia.builtin.test',
+        name: 'Test Device',
+        description: 'Test Almond in various ways',
+        kind: 'org.thingpedia.builtin.test',
+        ownerTier: 'global' },
+      { uniqueId: 'com.xkcd',
+        name: 'XKCD',
+        description: 'A webcomic of romance, sarcasm, math, and language.',
+        kind: 'com.xkcd',
+        ownerTier: 'global' }
     ]);
 }
 
@@ -271,7 +313,7 @@ async function testMyApiOAuth(accessToken) {
     const uniqueId = await testMyApiCreateWhenApp(auth);
     await testMyApiListApps(auth, uniqueId);
     await testMyApiDeleteApp(auth, uniqueId);
-    await testMyApiListDevices(auth);
+    await testMyApiDevices(auth);
     await testMyApiInvalid(auth);
     await testMyApiConverse(auth);
 }


### PR DESCRIPTION
In a twist of fate, both Home Assistant and BotFramework dislike our WebSocket-based conversation API. To accomodate them, add a REST based API that tracks state using a unique token.

Additionally, we add a REST API for Home Assistant to configure new devices. This way HA can set up itself when Almond is linked, so HA's entities (lights) can be controlled from Almond.

NOTE: this PR is against the stable branch because I want to release this in production soon, and the master branch is not in a good state.