### PR TITLE
update deleteNamedspaceJob due to api change

### DIFF
--- a/tests/unit/index.js
+++ b/tests/unit/index.js
@@ -26,5 +26,6 @@ seq([
     ('./test_exact_matcher'),
     ('./test_nlp_compat'),
     ('./test_example_names'),
-    ('./test_alexa_intent_parser')
+    ('./test_alexa_intent_parser'),
+    ('./test_k8s_api.js')
 ]);

--- a/tests/unit/test_k8s_api.js
+++ b/tests/unit/test_k8s_api.js
@@ -1,0 +1,57 @@
+// -*- mode: js; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of ThingEngine
+//
+// Copyright 2019 The Board of Trustees of the Leland Stanford Junior University
+//
+// Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
+//
+// See COPYING for details
+'use strict';
+
+function getArgs(func) {
+  var args = func.toString().match(/\S+\s*?\(([^)]*)\)/)[1];
+  return args.split(',').map(function(arg) {
+    return arg.replace(/\/\*.*\*\//, '').trim();
+  }).filter(function(arg) {
+    return arg;
+  });
+}
+
+const assert = require('assert');
+const k8s = require('@kubernetes/client-node');
+const fakeConfig = {
+    clusters: [
+        {
+            name: 'cluster',
+            server: 'foo.bar.com',
+        }
+    ],
+    contexts: [
+        {
+            cluster: 'cluster',
+            user: 'user',
+        }
+    ],
+    users: [
+        {
+            name: 'user',
+        }
+    ],
+};
+const kc = new k8s.KubeConfig();
+Object.assign(kc, fakeConfig);
+const k8sApi = kc.makeApiClient(k8s.BatchV1Api);
+
+function testdeleteNamespacedJob() {
+    assert.strictEqual(getArgs(k8sApi.deleteNamespacedJob)[6], 'propagationPolicy')
+}
+
+
+function main() {
+    console.log(getArgs(k8sApi.deleteNamespacedJob))
+    testdeleteNamespacedJob();
+}
+module.exports = main;
+if (!module.parent)
+    main();

--- a/tests/unit/test_k8s_api.js
+++ b/tests/unit/test_k8s_api.js
@@ -44,12 +44,13 @@ Object.assign(kc, fakeConfig);
 const k8sApi = kc.makeApiClient(k8s.BatchV1Api);
 
 function testdeleteNamespacedJob() {
+    assert.strictEqual(getArgs(k8sApi.deleteNamespacedJob)[0], 'name')
+    assert.strictEqual(getArgs(k8sApi.deleteNamespacedJob)[1], 'namespace')
     assert.strictEqual(getArgs(k8sApi.deleteNamespacedJob)[6], 'propagationPolicy')
 }
 
 
 function main() {
-    console.log(getArgs(k8sApi.deleteNamespacedJob))
     testdeleteNamespacedJob();
 }
 module.exports = main;

--- a/training/backends/kubernetes.js
+++ b/training/backends/kubernetes.js
@@ -119,7 +119,6 @@ const watcher = new class JobWatcher extends Tp.Helpers.RefCounted {
             console.log('job suceeded');
             k8sApi.deleteNamespacedJob(k8sJob.metadata.name, k8sJob.metadata.namespace,
                 undefined /*pretty*/,
-                undefined /*body*/,
                 undefined /*dryRun*/,
                 undefined /*gracePeriodSeconds*/,
                 undefined /*orphanDependents*/,
@@ -157,7 +156,6 @@ class KubernetesTaskRunner {
         console.log('killing job', this._k8sJob.metadata.name);
         k8sApi.deleteNamespacedJob(this._k8sJob.metadata.name, this._k8sJob.metadata.namespace,
             undefined /*pretty*/,
-            undefined /*body*/,
             undefined /*dryRun*/,
             undefined /*gracePeriodSeconds*/,
             undefined /*orphanDependents*/,


### PR DESCRIPTION
k8s api changed caused deleteNamedspaceJob not removing orphan pods.  Wrote a test case to detect  future changes. Not sure how to catch this kind of API changes in general for js though.