### PR TITLE
k8s: enable experimental Workers in node

### DIFF
--- a/training/backends/kubernetes.js
+++ b/training/backends/kubernetes.js
@@ -216,6 +216,7 @@ module.exports = async function execTask(job, spec) {
                             image: Config.TRAINING_KUBERNETES_IMAGE + (spec.requests.gpu > 0 ? '-cuda' : ''),
                             imagePullPolicy: 'Always',
                             command: [ '/usr/bin/node',
+                                '--experimental-worker',
                                 '--max_old_space_size=' + Config.TRAINING_MEMORY_USAGE,
                                 '/opt/almond-cloud/main.js',
                                 'run-training-task',


### PR DESCRIPTION
Otherwise contextual generation runs single-threaded and that's deadly