### PR TITLE
nlp/query: in MultipleChoice mode, tokenize all choices first

### DIFF
--- a/nlp/query.js
+++ b/nlp/query.js
@@ -141,10 +141,11 @@ async function query(params, data, service, res) {
             score: 'Infinity'
         }];
     } else if (expect === 'MultipleChoice') {
-        result = (data.choices || []).map((choice, i) => {
+        const choices = await Promise.all((data.choices || []).map((choice) => service.tokenizer.tokenize(languageTag, choice, expect)));
+        result = choices.map((choice, i) => {
             return {
                 code: ['bookkeeping', 'choice', String(i)],
-                score: -editDistance(tokens, choice.split(' '))
+                score: -editDistance(tokens, choice.tokens)
             };
         });
         result.sort((a, b) => b.score - a.score);

--- a/tests/nlp/index.js
+++ b/tests/nlp/index.js
@@ -203,6 +203,12 @@ async function testMultipleChoice(text, expected) {
 
     assert.deepStrictEqual(analyzed.entities, {});
     assert.deepStrictEqual(analyzed.candidates[0].code, ['bookkeeping', 'choice', expected]);
+
+    const analyzed2 = await parser.sendUtterance(text, '', 'MultipleChoice',
+        [{ title: 'CHOICE NUMBER ONE' }, { title: 'Choice Number Two' }]);
+
+    assert.deepStrictEqual(analyzed2.entities, {});
+    assert.deepStrictEqual(analyzed2.candidates[0].code, ['bookkeeping', 'choice', expected]);
 }
 
 async function testOnlineLearn() {


### PR DESCRIPTION
This ensures they are properly lower-cased and normalized, so they
have a chance of matching the input from the user, which is also
lower-cased.