### PR TITLE
enable requests fanout to k8s replicas in nlp server

### DIFF
--- a/config.js
+++ b/config.js
@@ -338,6 +338,14 @@ module.exports.NL_TOKENIZER_ADDRESS = '127.0.0.1:8888';
 module.exports.NL_MODEL_DIR = './models';
 
 /**
+  NLP Service name.
+
+  The kubernetes service name for NLP server.
+
+*/
+module.exports.NL_SERVICE_NAME = 'nlp';
+
+/**
   Training server URL.
 
   This URL will be called from the Thingpedia web server when a new device

--- a/doc/almond-config-file-reference.md
+++ b/doc/almond-config-file-reference.md
@@ -331,6 +331,14 @@ server. This is not a valid setting for the inference server.
 
 Default value: `'./models'`
 
+## NL_SERVICE_NAME
+NLP Service name.
+
+The kubernetes service name for NLP server.
+
+
+Default value: `'nlp'`
+
 ## TRAINING_URL
 Training server URL.
 

--- a/model/example.js
+++ b/model/example.js
@@ -400,6 +400,10 @@ module.exports = {
             where language = ? and find_in_set('exact', flags) and not is_base and preprocessed <> ''
             order by type asc, id asc`, [language]);
     },
+    
+    getExactById(client, exampleId) {
+        return db.selectOne(client, `select preprocessed,target_code from example_utterances where id = ?`, [exampleId]);
+    },
 
     suggest(client, command) {
         return db.query(client, "insert into command_suggestions (command) values (?)", command);

--- a/nlp/admin.js
+++ b/nlp/admin.js
@@ -30,6 +30,7 @@ router.use((req, res, next) => {
 });
 
 router.post('/reload/exact/@:model_tag/:locale', (req, res, next) => {
+    console.log('req.body', req.body);
     if (!i18n.get(req.params.locale, false)) {
         res.status(404).json({ error: 'Unsupported language' });
         return;
@@ -42,6 +43,8 @@ router.post('/reload/exact/@:model_tag/:locale', (req, res, next) => {
     }
 
     db.withClient((dbClient) => {
+        if (req.body.example_id)
+            return matcher.addExample(dbClient, req.body.example_id);
         return matcher.load(dbClient);
     }).then(() => {
         res.json({ result: 'ok' });

--- a/nlp/admin.js
+++ b/nlp/admin.js
@@ -30,7 +30,6 @@ router.use((req, res, next) => {
 });
 
 router.post('/reload/exact/@:model_tag/:locale', (req, res, next) => {
-    console.log('req.body', req.body);
     if (!i18n.get(req.params.locale, false)) {
         res.status(404).json({ error: 'Unsupported language' });
         return;

--- a/nlp/admin.js
+++ b/nlp/admin.js
@@ -23,7 +23,10 @@ router.use((req, res, next) => {
         res.status(401).json({ error: 'Not Authorized' });
         return;
     }
-    next();
+    if (!req.app.proxy || req.app.proxy.isProxy(req)) 
+        next();
+    else
+        req.app.proxy.fanout(req, res);
 });
 
 router.post('/reload/exact/@:model_tag/:locale', (req, res, next) => {

--- a/nlp/exact.js
+++ b/nlp/exact.js
@@ -44,6 +44,12 @@ module.exports = class ExactMatcher {
         console.log(`Loaded ${rows.length} exact matches for language ${this._language}`);
     }
 
+    async addExample(dbClient, exampleId) {
+        const row = await exampleModel.getExactById(dbClient, exampleId);
+        this.add(row.preprocessed, row.target_code);
+        console.log(`Added ${exampleId} for language ${this._language}`);
+    }
+
     add(utterance, target_code) {
         utterance = utterance.split(' ');
         target_code = target_code.split(' ');

--- a/nlp/learn.js
+++ b/nlp/learn.js
@@ -141,7 +141,7 @@ async function learn(req, res) {
     if (trainable) {
         model.exact.add(preprocessed, target_code);
         if (req.app.proxy) {
-            // call other replicas to reloads the new example
+            // call other replicas to reload the new example
             const path = `/admin/reload/exact/@${req.params.model_tag}/${req.params.locale}?admin_token=${Config.NL_SERVER_ADMIN_TOKEN}`;
             const promises = [];
             for (const replica of await req.app.proxy.getEndpoints(Config.NL_SERVICE_NAME, true)) {

--- a/nlp/learn.js
+++ b/nlp/learn.js
@@ -11,6 +11,7 @@
 
 const express = require('express');
 const ThingTalk = require('thingtalk');
+const Tp = require('thingpedia');
 
 const router = express.Router();
 
@@ -19,15 +20,9 @@ const iv = require('../util/input_validation');
 const I18n = require('../util/i18n');
 const userModel = require('../model/user');
 const exampleModel = require('../model/example');
+const Config = require('../config');
 
 const LATEST_THINGTALK_VERSION = ThingTalk.version;
-
-router.use(async (req, res, next) => {
-    if (!req.app.proxy || req.app.proxy.isProxy(req) || !req.url.endsWith('/learn')) 
-        next();
-    else
-        req.app.proxy.fanout(req, res);
-});
 
 async function learn(req, res) {
     let store = req.body.store;
@@ -124,7 +119,7 @@ async function learn(req, res) {
             }
         }
 
-        const ex = await exampleModel.create(dbClient, {
+        const exid = await exampleModel.create(dbClient, {
             is_base: false,
             language: languageTag,
             utterance: utterance,
@@ -137,15 +132,27 @@ async function learn(req, res) {
             like_count: 0
         });
         if (store === 'commandpedia')
-            await exampleModel.like(dbClient, ex.id, ownerId);
-        return ex.id;
+            await exampleModel.like(dbClient, exid, ownerId);
+        return exid;
     });
-    if (exampleId === null)
+    if (!exampleId)
         return;
 
-    if (trainable)
+    if (trainable) {
         model.exact.add(preprocessed, target_code);
-
+        if (req.app.proxy) {
+            // call other replicas to reloads the new example
+            const path = `/admin/reload/exact/@${req.params.model_tag}/${req.params.locale}?admin_token=${Config.NL_SERVER_ADMIN_TOKEN}`;
+            const promises = [];
+            for (const replica of await req.app.proxy.getEndpoints(Config.NL_SERVICE_NAME, true)) {
+                promises.push(Tp.Helpers.Http.post( `http://${replica}${path}`, `example_id=${encodeURIComponent(exampleId)}`, {
+                    dataContentType: 'application/x-www-form-urlencoded',
+                    extraHeaders: req.app.proxy.header()
+                }));
+            }
+            await Promise.all(promises);
+        }
+    }
     res.status(200).json({ result: 'Learnt successfully', example_id: exampleId });
 }
 

--- a/nlp/learn.js
+++ b/nlp/learn.js
@@ -22,6 +22,13 @@ const exampleModel = require('../model/example');
 
 const LATEST_THINGTALK_VERSION = ThingTalk.version;
 
+router.use(async (req, res, next) => {
+    if (!req.app.proxy || req.app.proxy.isProxy(req) || !req.url.endsWith('/learn')) 
+        next();
+    else
+        req.app.proxy.fanout(req, res);
+});
+
 async function learn(req, res) {
     let store = req.body.store;
     if (['no', 'automatic', 'online', 'commandpedia'].indexOf(store) < 0) {

--- a/nlp/main.js
+++ b/nlp/main.js
@@ -28,6 +28,7 @@ const I18n = require('../util/i18n');
 const NLPModel = require('./nlp_model');
 const FrontendClassifier = require('./classifier');
 const ExactMatcher = require('./exact');
+const ProxyServer = require('./proxy');
 
 const Config = require('../config');
 
@@ -113,6 +114,10 @@ class NLPInferenceServer {
 
     initFrontend(port) {
         const app = express();
+
+        // proxy enables requests fanout to all replcas in a nlp service
+        if (Config.TRAINING_TASK_BACKEND === 'kubernetes')
+            app.proxy = new ProxyServer(Config.NL_SERVICE_NAME);
 
         app.service = this;
         app.set('port', port);

--- a/nlp/proxy.js
+++ b/nlp/proxy.js
@@ -1,0 +1,90 @@
+
+// -*- mode: js; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of Almond
+//
+// Copyright 2019 The Board of Trustees of the Leland Stanford Junior University
+//
+// Author: Jim Deng <jim.deng@alumni.stanford.edu>
+//
+// See COPYING for details
+"use strict";
+
+const httpProxy = require('http-proxy');
+const queryString = require('querystring');
+const k8s = require('@kubernetes/client-node');
+
+// ProxyServer fans out http requests to all replicas in 
+// a kubernetes service.  Can only be used with kubernetes backend.
+module.exports = class ProxyServer {
+    constructor(name) {
+        // k8s service name
+        this.name = name;
+
+        // setup k8s api
+        const kc = new k8s.KubeConfig();
+        kc.loadFromDefault();
+        this.coreApi = kc.makeApiClient(k8s.CoreV1Api);
+
+        // setup proxy
+        this.proxy = httpProxy.createProxyServer();
+        this.proxy.on('proxyReq', (proxyReq, req, res, options) => {
+            // set header to identify the request is proxyed
+            proxyReq.setHeader('X-Almond-Fanout', 'true');
+
+            // use original url in proxy request
+            proxyReq.path = req.originalUrl;
+
+            // restream parsed body before proxying. Otherwise, 
+            // the the proxy request will hang in reading a stream.
+            if (!req.body || !Object.keys(req.body).length) 
+              return;
+
+            var contentType = proxyReq.getHeader('Content-Type');
+            var bodyData;
+
+            if (contentType === 'application/json')
+              bodyData = JSON.stringify(req.body);
+
+            if (contentType === 'application/x-www-form-urlencoded') 
+              bodyData = queryString.stringify(req.body);
+
+            if (bodyData) {
+              proxyReq.setHeader('Content-Length', Buffer.byteLength(bodyData));
+              proxyReq.write(bodyData);
+            }
+        });
+    }
+
+    async fanout(req, res) {
+        const replicas = await this.getEndpoints(this.name);
+        if (replicas.length === 0 )
+            throw new Error(`unexpected zero endpoints from ${this.name} service`);
+        console.log('forwarding requests to', replicas);
+        for (const ipPort of replicas) 
+            this.proxy.web(req, res, { target: `http://${ipPort}`} );
+    }
+
+    async getEndpoints(name) {
+        const ipPorts = [];
+        const resp = await this.coreApi.listEndpointsForAllNamespaces(
+            undefined /*allowWatchBookmarks*/,
+            undefined /*_continue*/, 
+            `metadata.name=${name}` /*fieldSelector*/);
+        for (const item of resp.body.items) {
+            for (const subset of item.subsets) {
+                if (!subset.ports || subset.ports.length === 0)
+                    throw new Error('failed to get endpoints port');
+                // use the first port since all addresses use the same port
+                const port = subset.ports[0].port;
+                for (const addr of subset.addresses)
+                    ipPorts.push(`${addr.ip}:${port}`);
+            }
+        }
+        return ipPorts;
+    }
+
+    isProxy(req) {
+        return req.header('X-Almond-Fanout') === 'true';
+    }
+};

--- a/nlp/proxy.js
+++ b/nlp/proxy.js
@@ -57,12 +57,17 @@ module.exports = class ProxyServer {
     }
 
     async fanout(req, res) {
-        const replicas = await this.getEndpoints(this.name);
-        if (replicas.length === 0 )
-            throw new Error(`unexpected zero endpoints from ${this.name} service`);
-        console.log('forwarding requests to', replicas);
-        for (const ipPort of replicas) 
-            this.proxy.web(req, res, { target: `http://${ipPort}`} );
+        try {
+            const replicas = await this.getEndpoints(this.name);
+            if (replicas.length === 0 )
+                throw new Error(`unexpected zero endpoints from ${this.name} service`);
+            console.log('fanout requests to', replicas);
+            for (const ipPort of replicas) 
+                this.proxy.web(req, res, { target: `http://${ipPort}`} );
+        } catch (e) {
+            console.log('fanout error:', e);
+            res.status(500).json({ error: 'Internal server errror' });
+        }
     }
 
     async getEndpoints(name) {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "gettext-parser": "^4.0.0",
     "gm": "^1.23.1",
     "highlight.js": "^9.13.1",
+    "http-proxy": "^1.18.0",
     "img-color-extractor": "^1.0.7",
     "js-yaml": "^3.12.0",
     "jsonwebtoken": "^8.3.0",

--- a/tests/unit/test_k8s_api.js
+++ b/tests/unit/test_k8s_api.js
@@ -4,11 +4,12 @@
 //
 // Copyright 2019 The Board of Trustees of the Leland Stanford Junior University
 //
-// Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
+// Author: Jim Deng <jim.deng@alumni.stanford.edu>
 //
 // See COPYING for details
 'use strict';
 
+// Tests k8s api signature does not change after upgrades 
 function getArgs(func) {
   var args = func.toString().match(/\S+\s*?\(([^)]*)\)/)[1];
   return args.split(',').map(function(arg) {
@@ -42,16 +43,23 @@ const fakeConfig = {
 const kc = new k8s.KubeConfig();
 Object.assign(kc, fakeConfig);
 const k8sApi = kc.makeApiClient(k8s.BatchV1Api);
+const k8sCore = kc.makeApiClient(k8s.CoreV1Api);
 
-function testdeleteNamespacedJob() {
-    assert.strictEqual(getArgs(k8sApi.deleteNamespacedJob)[0], 'name')
-    assert.strictEqual(getArgs(k8sApi.deleteNamespacedJob)[1], 'namespace')
-    assert.strictEqual(getArgs(k8sApi.deleteNamespacedJob)[6], 'propagationPolicy')
+function testDeleteNamespacedJob() {
+    const args = getArgs(k8sApi.deleteNamespacedJob);
+    assert.strictEqual(args[0], 'name');
+    assert.strictEqual(args[1], 'namespace');
+    assert.strictEqual(args[6], 'propagationPolicy');
 }
 
+function testListEndpointsForAllNamespaces() {
+    const args = getArgs(k8sCore.listEndpointsForAllNamespaces)
+    assert.strictEqual(args[2], 'fieldSelector');
+}
 
 function main() {
-    testdeleteNamespacedJob();
+    testDeleteNamespacedJob();
+    testListEndpointsForAllNamespaces();
 }
 module.exports = main;
 if (!module.parent)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1878,7 +1878,7 @@ debug@=3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@^3.1.0, debug@^3.2.6:
+debug@^3.0.0, debug@^3.1.0, debug@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -2535,6 +2535,11 @@ eventemitter2@~0.4.13:
   resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-0.4.14.tgz#8f61b75cde012b2e9eb284d4545583b5643b61ab"
   integrity sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=
 
+eventemitter3@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.0.tgz#d65176163887ee59f386d64c82610b696a4a74eb"
+  integrity sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==
+
 events@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
@@ -2919,6 +2924,13 @@ follow-redirects@1.5.10:
   integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
   dependencies:
     debug "=3.1.0"
+
+follow-redirects@^1.0.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.9.0.tgz#8d5bcdc65b7108fe1508649c79c12d732dcedb4f"
+  integrity sha512-CRcPzsSIbXyVDl0QI01muNDu69S8trU4jArW9LpOt2WtC6LyUJetcIrmfHsRBx7/Jb6GHJUiuqyYxPooFfNt6A==
+  dependencies:
+    debug "^3.0.0"
 
 foodoc@^0.0.9:
   version "0.0.9"
@@ -3710,6 +3722,15 @@ http-errors@~1.7.2:
     setprototypeof "1.1.1"
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
+
+http-proxy@^1.18.0:
+  version "1.18.0"
+  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.0.tgz#dbe55f63e75a347db7f3d99974f2692a314a6a3a"
+  integrity sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==
+  dependencies:
+    eventemitter3 "^4.0.0"
+    follow-redirects "^1.0.0"
+    requires-port "^1.0.0"
 
 http-signature@~1.2.0:
   version "1.2.0"
@@ -6662,6 +6683,11 @@ require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
+requires-port@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+  integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
 requizzle@^0.2.3:
   version "0.2.3"


### PR DESCRIPTION
by calling k8s api `listEndpointsForAllNamespaces` to get the ip ports and fanout admin/learn http requests to all replicas using http-proxy.

fixes #417 