### PR TITLE
i18n: fix initializing gettext in the sandboxed worker

### DIFF
--- a/almond/enginemanager.js
+++ b/almond/enginemanager.js
@@ -195,6 +195,8 @@ class EngineProcess extends events.EventEmitter {
             '--cdn-host', Config.CDN_HOST,
             '--oauth-redirect-origin', Config.OAUTH_REDIRECT_ORIGIN
         );
+        for (let lang of Config.SUPPORTED_LANGUAGES)
+            args.push('--locale', lang);
     }
 
     start() {

--- a/almond/worker.js
+++ b/almond/worker.js
@@ -24,6 +24,7 @@ const Engine = require('thingengine-core');
 const PlatformModule = require('./platform');
 const JsonDatagramSocket = require('../util/json_datagram_socket');
 const Assistant = require('./assistant');
+const i18n = require('../util/i18n');
 
 class ParentProcessSocket extends stream.Duplex {
     constructor() {
@@ -144,6 +145,11 @@ function main() {
         help: 'Run as a shared (multi-user) process',
         defaultValue: false,
     });
+    parser.addArgument(['-l', '--locale'], {
+        action: 'append',
+        defaultValue: [],
+        help: 'Enable this language',
+    });
     parser.addArgument('--thingpedia-url', {
         required: true,
         help: 'Thingpedia URL',
@@ -162,6 +168,7 @@ function main() {
     });
 
     const argv = parser.parseArgs();
+    i18n.init(argv.locale);
 
     // for compat with platform.getOrigin()
     // (but not platform.getCapability())

--- a/main.js
+++ b/main.js
@@ -18,6 +18,10 @@ const Q = require('q');
 Q.longStackSupport = true;
 process.on('unhandledRejection', (up) => { throw up; });
 require('./util/config_init');
+const i18n = require('./util/i18n');
+
+const Config = require('./config');
+i18n.init(Config.SUPPORTED_LANGUAGES);
 
 const argparse = require('argparse');
 


### PR DESCRIPTION
In the sandbox, access to the config is blocked, so we need to
pass the list of enabled languages on the command-line