### PR TITLE
Fix computing the automatic name of primitive templates

### DIFF
--- a/util/validation.js
+++ b/util/validation.js
@@ -154,8 +154,10 @@ function autogenExampleName(ex, names) {
 
     let counter = 1;
     let name = baseName + counter;
-    while (names.has(name))
+    while (names.has(name)) {
         counter ++;
+        name = baseName + counter;
+    }
     names.add(name);
     return name;
 }


### PR DESCRIPTION
Don't spin forever if there are more than two examples that would
compute to the same name.