### PR TITLE
Allow retrieving the datasets in "edit mode"

### DIFF
--- a/routes/thingpedia_api.js
+++ b/routes/thingpedia_api.js
@@ -1153,7 +1153,7 @@ v1.get('/examples/by-kinds/:kinds', (req, res, next) => {
 v3.get('/examples/by-kinds/:kinds', (req, res, next) => {
     var kinds = req.params.kinds.split(',');
     var client = new ThingpediaClient(req.query.developer_key, req.query.locale);
-    const accept = accepts(req).types(['application/x-thingtalk', 'application/json', 'text/html']);
+    const accept = accepts(req).types(['application/x-thingtalk', 'application/x-thingtalk;editMode=1', 'application/json', 'text/html']);
     if (!accept) {
         res.status(405).json({ error: 'must accept application/x-thingtalk or application/json' });
         return;

--- a/util/thingpedia-client.js
+++ b/util/thingpedia-client.js
@@ -340,8 +340,8 @@ module.exports = class ThingpediaClientCloud extends Tp.BaseClient {
         }
         return rows;
     }
-    _makeDataset(name, rows) {
-        return DatasetUtils.examplesToDataset(`org.thingpedia.dynamic.${name}`, this.language, rows);
+    _makeDataset(name, rows, options = {}) {
+        return DatasetUtils.examplesToDataset(`org.thingpedia.dynamic.${name}`, this.language, rows, options);
     }
 
     getExamplesByKey(key, accept = 'application/x-thingtalk') {
@@ -371,6 +371,12 @@ module.exports = class ThingpediaClientCloud extends Tp.BaseClient {
                 return this._datasetBackwardCompat(rows, true);
             case 'application/json':
                 return this._datasetBackwardCompat(rows, false);
+            case 'application/x-thingtalk;editMode=1':
+                if (kinds.length === 1)
+                    return DatasetUtils.examplesToDataset(kinds[0], this.language, rows, { editMode: true });
+
+                return this._makeDataset(`by_kinds.${kinds.map((k) => k.replace(/[^a-zA-Z0-9]+/g, '_')).join('__')}`,
+                    rows, { editMode: true });
             default:
                 return this._makeDataset(`by_kinds.${kinds.map((k) => k.replace(/[^a-zA-Z0-9]+/g, '_')).join('__')}`,
                     rows);


### PR DESCRIPTION
Edit mode removes #_[preprocessed], #[click_count] and #[like_count],
and if only one kind is requested, also edits the dataset name.