### PR TITLE
Consistently expose the canonical form of class names

### DIFF
--- a/model/schema.js
+++ b/model/schema.js
@@ -402,7 +402,7 @@ module.exports = {
             if (org === -1) {
                 return db.selectAll(client, `select dsc.name, channel_type, extends, canonical, confirmation,
                     confirmation_remote, formatted, doc, types, argnames, argcanonicals, required, is_input,
-                    string_values, is_list, is_monitorable, questions, confirm, kind, kind_type
+                    string_values, is_list, is_monitorable, questions, confirm, kind, kind_canonical, kind_type
                     from device_schema ds left join
                     device_schema_channels dsc on ds.id = dsc.schema_id and
                     dsc.version = ds.developer_version left join device_schema_channel_canonicals dscc
@@ -412,7 +412,7 @@ module.exports = {
             } if (org !== null) {
                 return db.selectAll(client, `select dsc.name, channel_type, extends, canonical, confirmation,
                     confirmation_remote, formatted, doc, types, argnames, argcanonicals, required, is_input,
-                    string_values, is_list, is_monitorable, questions, confirm, kind, kind_type
+                    string_values, is_list, is_monitorable, questions, confirm, kind, kind_canonical, kind_type
                     from device_schema ds left join
                     device_schema_channels dsc on ds.id = dsc.schema_id and
                     ((dsc.version = ds.developer_version and ds.owner = ?) or
@@ -424,7 +424,7 @@ module.exports = {
             } else {
                 return db.selectAll(client, `select dsc.name, channel_type, extends, canonical, confirmation,
                     confirmation_remote, formatted, doc, types, argnames, argcanonicals, required, is_input,
-                    string_values, is_list, is_monitorable, questions, confirm, kind, kind_type
+                    string_values, is_list, is_monitorable, questions, confirm, kind, kind_canonical, kind_type
                     from device_schema ds left join device_schema_channels
                     dsc on ds.id = dsc.schema_id and dsc.version = ds.approved_version left join
                     device_schema_channel_canonicals dscc on dscc.schema_id = dsc.schema_id and
@@ -438,7 +438,7 @@ module.exports = {
     getMetasByKindAtVersion(client, kind, version, language) {
         return Q.try(() => {
             return db.selectAll(client, "select dsc.name, channel_type, extends, canonical, confirmation, confirmation_remote, formatted, doc, types,"
-                                + " argnames, argcanonicals, required, is_input, string_values, is_list, is_monitorable, questions, confirm, kind, kind_type "
+                                + " argnames, argcanonicals, required, is_input, string_values, is_list, is_monitorable, questions, confirm, kind, kind_canonical, kind_type "
                                 + " from device_schema ds"
                                 + " left join device_schema_channels dsc on ds.id = dsc.schema_id"
                                 + " and dsc.version = ? "

--- a/tests/test_thingpedia_api_v3.js
+++ b/tests/test_thingpedia_api_v3.js
@@ -173,7 +173,8 @@ const BING_CLASS = `class @com.bing {
                                     out link: Entity(tt:url));
 }
 `;
-const BING_CLASS_WITH_METADATA = `class @com.bing {
+const BING_CLASS_WITH_METADATA = `class @com.bing
+#_[canonical="bing search"] {
   monitorable list query image_search(in req query: String #_[prompt="What do you want to search?"] #_[canonical="query"] #[string_values="tt:search_query"],
                                       out title: String #_[canonical="title"] #[string_values="tt:short_free_text"],
                                       out picture_url: Entity(tt:picture) #_[canonical="picture url"],
@@ -198,6 +199,7 @@ const BING_CLASS_WITH_METADATA = `class @com.bing {
 const BING_CLASS_FULL = `class @com.bing
 #_[name="Bing Search"]
 #_[description="Search the web with Bing"]
+#_[canonical="bing search"]
 #[version=0]
 #[package_version=0] {
   import loader from @org.thingpedia.v2();
@@ -237,14 +239,16 @@ const ADMINONLY_CLASS = `class @org.thingpedia.builtin.test.adminonly {
   action eat_data(in req data: String);
 }
 `;
-const INVISIBLE_CLASS_WITH_METADATA = `class @org.thingpedia.builtin.test.invisible {
+const INVISIBLE_CLASS_WITH_METADATA = `class @org.thingpedia.builtin.test.invisible
+#_[canonical="invisible device"] {
   action eat_data(in req data: String #_[prompt="What do you want me to consume?"] #_[canonical="data"])
   #_[canonical="eat data on test"]
   #_[confirmation="consume $data"]
   #[confirm=true];
 }
 `;
-const ADMINONLY_CLASS_WITH_METADATA = `class @org.thingpedia.builtin.test.adminonly {
+const ADMINONLY_CLASS_WITH_METADATA = `class @org.thingpedia.builtin.test.adminonly
+#_[canonical="admin-only device"] {
   action eat_data(in req data: String #_[prompt="What do you want me to consume?"] #_[canonical="data"])
   #_[canonical="eat data on test"]
   #_[confirmation="consume $data"]
@@ -2086,6 +2090,7 @@ module.exports = class TestDevice extends Tp.BaseDevice {
 const BANG_CLASS_FULL = `class @com.bing
 #_[name="Bang Search"]
 #_[description="Search the web with Bang"]
+#_[canonical="bang search"]
 #[version=1]
 #[package_version=1] {
   import loader from @org.thingpedia.v2();
@@ -2203,6 +2208,7 @@ async function testCreateDevice() {
     assert.strictEqual(manifest, `class @org.thingpedia.test.newdevice1
 #_[name="New Test Device"]
 #_[description="Yet another test device (can't have too many of those)"]
+#_[canonical="new test device"]
 #[version=0]
 #[package_version=0] {
   import loader from @org.thingpedia.v2();

--- a/util/import_device.js
+++ b/util/import_device.js
@@ -22,7 +22,6 @@ const exampleModel = require('../model/example');
 
 const user = require('./user');
 
-const tokenizer = require('./tokenize');
 const graphics = require('../almond/graphics');
 const colorScheme = require('./color_scheme');
 
@@ -75,7 +74,7 @@ async function ensurePrimarySchema(dbClient, name, classDef, req, approve) {
         }
 
         var obj = {
-            kind_canonical: tokenizer.tokenize(name).join(' '),
+            kind_canonical: classDef.metadata.canonical,
             developer_version: existing.developer_version + 1
         };
         if (approve)
@@ -86,7 +85,7 @@ async function ensurePrimarySchema(dbClient, name, classDef, req, approve) {
     }, async (e) => {
         var obj = {
             kind: classDef.kind,
-            kind_canonical: tokenizer.tokenize(name).join(' '),
+            kind_canonical: classDef.metadata.canonical,
             kind_type: 'primary',
             owner: req.user.developer_org
         };

--- a/util/validation.js
+++ b/util/validation.js
@@ -37,7 +37,7 @@ const FORBIDDEN_NAMES = new Set(['__count__', '__noSuchMethod__', '__parent__',
 
 const ALLOWED_ARG_METADATA = new Set(['canonical', 'prompt']);
 const ALLOWED_FUNCTION_METADATA = new Set(['canonical', 'confirmation', 'confirmation_remote', 'formatted']);
-const ALLOWED_CLASS_METADATA = new Set(['name', 'description', 'thingpedia_name', 'thingpedia_description']);
+const ALLOWED_CLASS_METADATA = new Set(['name', 'description', 'thingpedia_name', 'thingpedia_description', 'canonical']);
 
 function validateAnnotations(annotations) {
     for (let name of Object.getOwnPropertyNames(annotations)) {
@@ -132,6 +132,8 @@ async function validateDevice(dbClient, req, options, classCode, datasetCode) {
         classDef.metadata.name = name;
     if (!classDef.metadata.description)
         classDef.metadata.description = description;
+    if (!classDef.metadata.canonical)
+        classDef.metadata.canonical = tokenize(name).join(' ');
     await validateDataset(dataset);
 
     // delete annotations that are specific to devices uploaded with the "thingpedia" CLI tool


### PR DESCRIPTION
To properly fix https://github.com/stanford-oval/thingtalk/pull/171
without hacks, we need all classes to have #_[canonical] annotation.
As it happens, we're already storing that information, but we're
not exposing it consistently across APIs. This commit fixes that.