### PR TITLE
training/update-dataset: lower consistency level of update transaction

### DIFF
--- a/training/tasks/update-dataset.js
+++ b/training/tasks/update-dataset.js
@@ -237,7 +237,7 @@ class DatasetUpdater {
         await db.withTransaction((dbClient) => {
             this._dbClient = dbClient;
             return this._transaction();
-        }, 'repeatable read');
+        }, 'read committed');
     }
 }
 


### PR DESCRIPTION
According to the MySQL documentation:
https://dev.mysql.com/doc/refman/8.0/en/innodb-locking.html#innodb-next-key-locks
at REPEATABLE READ level, UPDATE and DELETE statements use gap & next key locking,
and may lock rows or index records that are not matched by the query
(to avoid phantoms).
This is likely the cause of deadlocks we're seeing when the update-dataset
task is run concurrently to a Thingpedia edit operation or a mturk
task, both of which try to insert into the example_utterances database
(Thingpedia also tries to delete & edit).

At READ COMMITTED level, on the other hand, only the rows matched
by the query are locked. In principle, this should be sufficient
to solve the problem, as the update-dataset task only deletes synthetic
data. (It also updates paraphrase data to mark obsolete sentences, but
it's fine if it misses some paraphrase sentences that are inserted concurrently,
because those won't be immediately obsolete).

I say in principle, because we've been played with locking for a while
now, and this has been a long-standing concurrency problem. But this
is a quick fix.