### PR TITLE
prepare-training-set: change how we set the eval flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,9 +130,9 @@
   "optionalDependencies": {
     "@kubernetes/client-node": "^0.11.0",
     "aws-sdk": "^2.2.48",
-    "selenium-webdriver": "^4.0.0-alpha.3",
     "dialogflow": "^0.5.0",
-    "dialogflow-fulfillment": "^0.5.0"
+    "dialogflow-fulfillment": "^0.5.0",
+    "selenium-webdriver": "^4.0.0-alpha.3"
   },
   "nyc": {
     "exclude": [

--- a/tests/load_test_thingpedia.js
+++ b/tests/load_test_thingpedia.js
@@ -221,7 +221,7 @@ async function loadExamples(dbClient, bob) {
         utterance: 'more data eating...',
         preprocessed: 'more data eating ...',
         target_json: '',
-        target_code: 'action  := @org.thingpedia.builtin.test.eat_data();',
+        target_code: 'action := @org.thingpedia.builtin.test.eat_data();',
         type: 'thingpedia',
         click_count: 0,
         flags: 'template',

--- a/tests/test_thingpedia_api_v3.js
+++ b/tests/test_thingpedia_api_v3.js
@@ -598,12 +598,12 @@ async function testGetExamplesByDevice() {
     assert.deepStrictEqual(await request('/examples/by-kinds/org.thingpedia.builtin.test'), TEST_EXAMPLES);
 
     assert.deepStrictEqual((await ttRequest('/examples/by-kinds/org.thingpedia.builtin.test')).trim(), `dataset @org.thingpedia.dynamic.by_kinds.org_thingpedia_builtin_test language "en" {
-    action  := @org.thingpedia.builtin.test.eat_data()
+    action := @org.thingpedia.builtin.test.eat_data()
     #_[utterances=["eat some data","more data eating..."]]
     #_[preprocessed=["eat some data","more data eating ..."]]
     #[id=1000] #[click_count=0] #[like_count=0]
     #[name="EatData"];
-    query (p_size :Measure(byte))  := @org.thingpedia.builtin.test.get_data(size=p_size)
+    query (p_size :Measure(byte)) := @org.thingpedia.builtin.test.get_data(size=p_size)
     #_[utterances=["get ${'${p_size}'} of data"]]
     #_[preprocessed=["get ${'${p_size}'} of data"]]
     #[id=1001] #[click_count=7] #[like_count=0]
@@ -613,7 +613,7 @@ async function testGetExamplesByDevice() {
     #_[preprocessed=["keep eating data !","keep eating data ! -lrb- v2 -rrb-"]]
     #[id=1002] #[click_count=0] #[like_count=0]
     #[name="GenDataThenEatData"];
-    query  := @org.thingpedia.builtin.test.get_data()
+    query := @org.thingpedia.builtin.test.get_data()
     #_[utterances=["more data genning..."]]
     #_[preprocessed=["more data genning ..."]]
     #[id=1005] #[click_count=0] #[like_count=0]
@@ -637,12 +637,12 @@ async function testGetExamplesByKey() {
     assert.deepStrictEqual(await request('/examples/search?q=data'), TEST_EXAMPLES);
 
     assert.deepStrictEqual(await ttRequest('/examples/search?q=data'), `dataset @org.thingpedia.dynamic.by_key.data language "en" {
-    action  := @org.thingpedia.builtin.test.eat_data()
+    action := @org.thingpedia.builtin.test.eat_data()
     #_[utterances=["eat some data","more data eating..."]]
     #_[preprocessed=["eat some data","more data eating ..."]]
     #[id=1000] #[click_count=0] #[like_count=0]
     #[name="EatData"];
-    query (p_size :Measure(byte))  := @org.thingpedia.builtin.test.get_data(size=p_size)
+    query (p_size :Measure(byte)) := @org.thingpedia.builtin.test.get_data(size=p_size)
     #_[utterances=["get ${'${p_size}'} of data"]]
     #_[preprocessed=["get ${'${p_size}'} of data"]]
     #[id=1001] #[click_count=7] #[like_count=0]
@@ -652,7 +652,7 @@ async function testGetExamplesByKey() {
     #_[preprocessed=["keep eating data !","keep eating data ! -lrb- v2 -rrb-"]]
     #[id=1002] #[click_count=0] #[like_count=0]
     #[name="GenDataThenEatData"];
-    query  := @org.thingpedia.builtin.test.get_data()
+    query := @org.thingpedia.builtin.test.get_data()
     #_[utterances=["more data genning..."]]
     #_[preprocessed=["more data genning ..."]]
     #[id=1005] #[click_count=0] #[like_count=0]
@@ -697,7 +697,7 @@ async function testGetCommands() {
       "type": "thingpedia",
       "utterance": "show me images from bing matching ____ larger than ____ x ____",
       "preprocessed": "images from bing matching ${p_query} larger than ${p_width} x ${p_height}",
-      "target_code": "query (p_query :String, p_width :Number, p_height :Number)  := (@com.bing.image_search(query=p_query)), (width >= p_width && height >= p_height);\n",
+      "target_code": "query (p_query :String, p_width :Number, p_height :Number) := (@com.bing.image_search(query=p_query)), (width >= p_width && height >= p_height);\n",
       "click_count": 1,
       "like_count": 0,
       "liked": false,
@@ -713,7 +713,7 @@ async function testGetCommands() {
       "type": "thingpedia",
       "utterance": "open the file at ____",
       "preprocessed": "open the file at ${p_url}",
-      "target_code": "action (p_url :Entity(tt:url))  := @org.thingpedia.builtin.thingengine.builtin.open_url(url=p_url);\n",
+      "target_code": "action (p_url :Entity(tt:url)) := @org.thingpedia.builtin.thingengine.builtin.open_url(url=p_url);\n",
       "click_count": 1,
       "like_count": 0,
       "liked": false,
@@ -729,7 +729,7 @@ async function testGetCommands() {
       "type": "thingpedia",
       "utterance": "show me texts i received in the last hour",
       "preprocessed": "texts i received in the last hour",
-      "target_code": "query  := (@org.thingpedia.builtin.thingengine.phone.sms()), date >= start_of(h);\n",
+      "target_code": "query := (@org.thingpedia.builtin.thingengine.phone.sms()), date >= start_of(h);\n",
       "click_count": 1,
       "like_count": 0,
       "liked": false,
@@ -745,7 +745,7 @@ async function testGetCommands() {
       "type": "thingpedia",
       "utterance": "call somebody",
       "preprocessed": "call somebody",
-      "target_code": "action  := @org.thingpedia.builtin.thingengine.phone.call(number=$?);\n",
+      "target_code": "action := @org.thingpedia.builtin.thingengine.phone.call(number=$?);\n",
       "click_count": 1,
       "like_count": 0,
       "liked": false,
@@ -761,7 +761,7 @@ async function testGetCommands() {
       "type": "thingpedia",
       "utterance": "throw a dice between ____ and ____",
       "preprocessed": ", throw a dice between ${p_low:const} and ${p_high:const}",
-      "target_code": "query (p_low :Number, p_high :Number)  := @org.thingpedia.builtin.thingengine.builtin.get_random_between(low=p_low, high=p_high);\n",
+      "target_code": "query (p_low :Number, p_high :Number) := @org.thingpedia.builtin.thingengine.builtin.get_random_between(low=p_low, high=p_high);\n",
       "click_count": 1,
       "like_count": 0,
       "liked": false,
@@ -777,7 +777,7 @@ async function testGetCommands() {
       "type": "thingpedia",
       "utterance": "show me a screenshot of my laptop",
       "preprocessed": "a screenshot of my laptop",
-      "target_code": "query  := @org.thingpedia.builtin.thingengine.gnome.get_screenshot();\n",
+      "target_code": "query := @org.thingpedia.builtin.thingengine.gnome.get_screenshot();\n",
       "click_count": 1,
       "like_count": 0,
       "liked": false,
@@ -793,7 +793,7 @@ async function testGetCommands() {
       "type": "thingpedia",
       "utterance": "howdy",
       "preprocessed": "howdy",
-      "target_code": "program  := {\n  now => @org.thingpedia.builtin.thingengine.builtin.canned_reply(intent=enum(hello)) => notify;\n};\n",
+      "target_code": "program := {\n  now => @org.thingpedia.builtin.thingengine.builtin.canned_reply(intent=enum(hello)) => notify;\n};\n",
       "click_count": 1,
       "like_count": 0,
       "liked": false,
@@ -809,7 +809,7 @@ async function testGetCommands() {
       "type": "thingpedia",
       "utterance": "generate a random number between ____ and ____",
       "preprocessed": ", generate a random number between ${p_low:const} and ${p_high:const}",
-      "target_code": "query (p_low :Number, p_high :Number)  := @org.thingpedia.builtin.thingengine.builtin.get_random_between(low=p_low, high=p_high);\n",
+      "target_code": "query (p_low :Number, p_high :Number) := @org.thingpedia.builtin.thingengine.builtin.get_random_between(low=p_low, high=p_high);\n",
       "click_count": 1,
       "like_count": 0,
       "liked": false,
@@ -868,7 +868,7 @@ async function testGetCommands() {
       "type": "thingpedia",
       "utterance": "show me a screenshot of my laptop",
       "preprocessed": "a screenshot of my laptop",
-      "target_code": "query  := @org.thingpedia.builtin.thingengine.gnome.get_screenshot();\n",
+      "target_code": "query := @org.thingpedia.builtin.thingengine.gnome.get_screenshot();\n",
       "click_count": 1,
       "like_count": 0,
       "is_base": 1,
@@ -883,7 +883,7 @@ async function testGetCommands() {
       "type": "thingpedia",
       "utterance": "create a file named ____ on my laptop",
       "preprocessed": "create a file named ${p_file_name:const} on my laptop",
-      "target_code": "action (p_file_name :Entity(tt:path_name))  := @org.thingpedia.builtin.thingengine.gnome.create_file(file_name=p_file_name, contents=$?);\n",
+      "target_code": "action (p_file_name :Entity(tt:path_name)) := @org.thingpedia.builtin.thingengine.gnome.create_file(file_name=p_file_name, contents=$?);\n",
       "click_count": 1,
       "like_count": 0,
       "is_base": 1,
@@ -898,7 +898,7 @@ async function testGetCommands() {
       "type": "thingpedia",
       "utterance": "turn ____ my laptop",
       "preprocessed": "turn ${p_power} my laptop",
-      "target_code": "action (p_power :Enum(on,off))  := @org.thingpedia.builtin.thingengine.gnome.set_power(power=p_power);\n",
+      "target_code": "action (p_power :Enum(on,off)) := @org.thingpedia.builtin.thingengine.gnome.set_power(power=p_power);\n",
       "click_count": 1,
       "like_count": 0,
       "is_base": 1,
@@ -913,7 +913,7 @@ async function testGetCommands() {
       "type": "thingpedia",
       "utterance": "delete a file from my laptop",
       "preprocessed": "delete a file from my laptop",
-      "target_code": "action  := @org.thingpedia.builtin.thingengine.gnome.delete_file(file_name=$?);\n",
+      "target_code": "action := @org.thingpedia.builtin.thingengine.gnome.delete_file(file_name=$?);\n",
       "click_count": 1,
       "like_count": 0,
       "is_base": 1,
@@ -928,7 +928,7 @@ async function testGetCommands() {
       "type": "thingpedia",
       "utterance": "use ____ as the background of my laptop",
       "preprocessed": "use ${p_picture_url} as the background of my laptop",
-      "target_code": "action (p_picture_url :Entity(tt:picture))  := @org.thingpedia.builtin.thingengine.gnome.set_background(picture_url=p_picture_url);\n",
+      "target_code": "action (p_picture_url :Entity(tt:picture)) := @org.thingpedia.builtin.thingengine.gnome.set_background(picture_url=p_picture_url);\n",
       "click_count": 1,
       "like_count": 0,
       "is_base": 1,
@@ -943,7 +943,7 @@ async function testGetCommands() {
       "type": "thingpedia",
       "utterance": "save a screenshot of my laptop",
       "preprocessed": ", save a screenshot of my laptop",
-      "target_code": "query  := @org.thingpedia.builtin.thingengine.gnome.get_screenshot();\n",
+      "target_code": "query := @org.thingpedia.builtin.thingengine.gnome.get_screenshot();\n",
       "click_count": 1,
       "like_count": 0,
       "is_base": 1,
@@ -958,7 +958,7 @@ async function testGetCommands() {
       "type": "thingpedia",
       "utterance": "lock my laptop",
       "preprocessed": "lock my laptop",
-      "target_code": "action  := @org.thingpedia.builtin.thingengine.gnome.lock();\n",
+      "target_code": "action := @org.thingpedia.builtin.thingengine.gnome.lock();\n",
       "click_count": 1,
       "like_count": 0,
       "is_base": 1,
@@ -973,7 +973,7 @@ async function testGetCommands() {
       "type": "thingpedia",
       "utterance": "set the background of my laptop to ____",
       "preprocessed": "set the background of my laptop to ${p_picture_url}",
-      "target_code": "action (p_picture_url :Entity(tt:picture))  := @org.thingpedia.builtin.thingengine.gnome.set_background(picture_url=p_picture_url);\n",
+      "target_code": "action (p_picture_url :Entity(tt:picture)) := @org.thingpedia.builtin.thingengine.gnome.set_background(picture_url=p_picture_url);\n",
       "click_count": 1,
       "like_count": 0,
       "is_base": 1,
@@ -988,7 +988,7 @@ async function testGetCommands() {
       "type": "thingpedia",
       "utterance": "change the background on my laptop",
       "preprocessed": "change the background on my laptop",
-      "target_code": "action  := @org.thingpedia.builtin.thingengine.gnome.set_background(picture_url=$?);\n",
+      "target_code": "action := @org.thingpedia.builtin.thingengine.gnome.set_background(picture_url=$?);\n",
       "click_count": 1,
       "like_count": 0,
       "is_base": 1,
@@ -1003,7 +1003,7 @@ async function testGetCommands() {
       "type": "thingpedia",
       "utterance": "create a file named ____ on my laptop containing ____",
       "preprocessed": "create a file named ${p_file_name:const} on my laptop containing ${p_contents}",
-      "target_code": "action (p_file_name :Entity(tt:path_name), p_contents :String)  := @org.thingpedia.builtin.thingengine.gnome.create_file(file_name=p_file_name, contents=p_contents);\n",
+      "target_code": "action (p_file_name :Entity(tt:path_name), p_contents :String) := @org.thingpedia.builtin.thingengine.gnome.create_file(file_name=p_file_name, contents=p_contents);\n",
       "click_count": 1,
       "like_count": 0,
       "is_base": 1,
@@ -1018,7 +1018,7 @@ async function testGetCommands() {
       "type": "thingpedia",
       "utterance": "open ____ on my laptop",
       "preprocessed": "open ${p_app_id} on my laptop",
-      "target_code": "action (p_app_id :Entity(org.freedesktop:app_id))  := @org.thingpedia.builtin.thingengine.gnome.open_app(app_id=p_app_id);\n",
+      "target_code": "action (p_app_id :Entity(org.freedesktop:app_id)) := @org.thingpedia.builtin.thingengine.gnome.open_app(app_id=p_app_id);\n",
       "click_count": 1,
       "like_count": 0,
       "is_base": 1,
@@ -1033,7 +1033,7 @@ async function testGetCommands() {
       "type": "thingpedia",
       "utterance": "delete the file named ____ from my laptop",
       "preprocessed": "delete the file named ${p_file_name:const} from my laptop",
-      "target_code": "action (p_file_name :Entity(tt:path_name))  := @org.thingpedia.builtin.thingengine.gnome.delete_file(file_name=p_file_name);\n",
+      "target_code": "action (p_file_name :Entity(tt:path_name)) := @org.thingpedia.builtin.thingengine.gnome.delete_file(file_name=p_file_name);\n",
       "click_count": 1,
       "like_count": 0,
       "is_base": 1,
@@ -1048,7 +1048,7 @@ async function testGetCommands() {
       "type": "thingpedia",
       "utterance": "take a screenshot of my laptop",
       "preprocessed": ", take a screenshot of my laptop",
-      "target_code": "query  := @org.thingpedia.builtin.thingengine.gnome.get_screenshot();\n",
+      "target_code": "query := @org.thingpedia.builtin.thingengine.gnome.get_screenshot();\n",
       "click_count": 1,
       "like_count": 0,
       "is_base": 1,
@@ -1063,7 +1063,7 @@ async function testGetCommands() {
       "type": "thingpedia",
       "utterance": "open ____ with ____ on my laptop",
       "preprocessed": "open ${p_url} with ${p_app_id} on my laptop",
-      "target_code": "action (p_url :Entity(tt:url), p_app_id :Entity(org.freedesktop:app_id))  := @org.thingpedia.builtin.thingengine.gnome.open_app(app_id=p_app_id, url=p_url);\n",
+      "target_code": "action (p_url :Entity(tt:url), p_app_id :Entity(org.freedesktop:app_id)) := @org.thingpedia.builtin.thingengine.gnome.open_app(app_id=p_app_id, url=p_url);\n",
       "click_count": 1,
       "like_count": 0,
       "is_base": 1,
@@ -1078,7 +1078,7 @@ async function testGetCommands() {
       "type": "thingpedia",
       "utterance": "delete ____ from my laptop",
       "preprocessed": "delete ${p_file_name} from my laptop",
-      "target_code": "action (p_file_name :Entity(tt:path_name))  := @org.thingpedia.builtin.thingengine.gnome.delete_file(file_name=p_file_name);\n",
+      "target_code": "action (p_file_name :Entity(tt:path_name)) := @org.thingpedia.builtin.thingengine.gnome.delete_file(file_name=p_file_name);\n",
       "click_count": 1,
       "like_count": 0,
       "is_base": 1,
@@ -1093,7 +1093,7 @@ async function testGetCommands() {
       "type": "thingpedia",
       "utterance": "activate the lock screen on my laptop",
       "preprocessed": "activate the lock screen on my laptop",
-      "target_code": "action  := @org.thingpedia.builtin.thingengine.gnome.lock();\n",
+      "target_code": "action := @org.thingpedia.builtin.thingengine.gnome.lock();\n",
       "click_count": 1,
       "like_count": 0,
       "is_base": 1,
@@ -2247,34 +2247,34 @@ async function testCreateDevice() {
 
 const BING_DATASET = `
 dataset @com.bing language "en" {
-    query (p_query :String)  := @com.bing.web_search(query=p_query)
+    query (p_query :String) := @com.bing.web_search(query=p_query)
     #_[utterances=["${'${p_query:const}'} on bing","bing $p_query","websites matching $p_query","web sites matching $p_query"]];
 
-    query  := @com.bing.web_search(query=$?)
+    query := @com.bing.web_search(query=$?)
     #_[utterances=[", search on bing",", bing search",", web search"]];
 
-    query (p_query :String)  := @com.bing.image_search(query=p_query)
+    query (p_query :String) := @com.bing.image_search(query=p_query)
     #_[utterances=["${'${p_query:const}'} images on bing","images matching $p_query from bing"]];
 
-    query  := @com.bing.image_search(query=$?)
+    query := @com.bing.image_search(query=$?)
     #_[utterances=[", search images on bing",", bing image search",", image search"]];
 
-    query (p_query :String, p_width :Number, p_height :Number)  := (@com.bing.image_search(query=p_query)), (width == p_width && height == p_height)
+    query (p_query :String, p_width :Number, p_height :Number) := (@com.bing.image_search(query=p_query)), (width == p_width && height == p_height)
     #_[utterances=["images from bing matching $p_query with size $p_width x $p_height"]];
 
-    query (p_query :String, p_width :Number, p_height :Number)  := (@com.bing.image_search(query=p_query)), (width >= p_width && height >= p_height)
+    query (p_query :String, p_width :Number, p_height :Number) := (@com.bing.image_search(query=p_query)), (width >= p_width && height >= p_height)
     #_[utterances=["images from bing matching $p_query larger than $p_width x $p_height"]];
 
-    query (p_query :String, p_width :Number)  := (@com.bing.image_search(query=p_query)), width >= p_width
+    query (p_query :String, p_width :Number) := (@com.bing.image_search(query=p_query)), width >= p_width
     #_[utterances=["images from bing matching $p_query wider than $p_width"]];
 
-    query (p_query :String, p_width :Number, p_height :Number)  := (@com.bing.image_search(query=p_query)), (width >= p_width || height >= p_height)
+    query (p_query :String, p_width :Number, p_height :Number) := (@com.bing.image_search(query=p_query)), (width >= p_width || height >= p_height)
     #_[utterances=["images from bing matching $p_query larger than $p_width x $p_height in either dimension"]];
 
-    query (p_query :String, p_height :Number)  := (@com.bing.image_search(query=p_query)), height >= p_height
+    query (p_query :String, p_height :Number) := (@com.bing.image_search(query=p_query)), height >= p_height
     #_[utterances=["images from bing matching $p_query taller than $p_height"]];
 
-    query (p_query :String, p_width :Number, p_height :Number)  := (@com.bing.image_search(query=p_query)), (width <= p_width && height <= p_height)
+    query (p_query :String, p_width :Number, p_height :Number) := (@com.bing.image_search(query=p_query)), (width <= p_width && height <= p_height)
     #_[utterances=["images from bing matching $p_query smaller than $p_width x $p_height"]];
   }
 `;

--- a/tests/thingpedia-integration.sh
+++ b/tests/thingpedia-integration.sh
@@ -170,9 +170,9 @@ node ${srcdir}/main.js run-training-task -t prepare-training-set --job-id 2 --jo
 
 sha256sum exact.tsv ./training/jobs/2/dataset/eval.tsv ./training/jobs/2/dataset/train.tsv
 sha256sum -c <<EOF
-f71f1e8c2df27ef83b259918c58eea9c0208addf27abdfbc87e18136ad42475a  exact.tsv
-841ac7dc62bbc3de54e850722dd22679672f01dd176bac87d2e9e82a665b9222  ./training/jobs/2/dataset/eval.tsv
-6df22c612bb9eccd94fa1c0fb5c436171b6fd73a6a65a3c9418b366496237cfe  ./training/jobs/2/dataset/train.tsv
+4f5cf920c59aca48c571d65b1f5ce4a1be735549d6834fa5660f3f0342ee1b8f  exact.tsv
+3ac80766f6627704c85572340a9cf034a9b0cdb9fe5ccce8e91f6af0829e5eb9  ./training/jobs/2/dataset/eval.tsv
+9f2e32fbb57a6d5ab627024dc6f653cb283ca82ed848b4865222d78e366856fe  ./training/jobs/2/dataset/train.tsv
 EOF
 
 rm -rf $workdir

--- a/training/tasks/prepare-training-set.js
+++ b/training/tasks/prepare-training-set.js
@@ -29,19 +29,24 @@ const genSynthetic = require('../sandboxed_synthetic_gen');
 const schemaModel = require('../../model/schema');
 const orgModel = require('../../model/organization');
 const db = require('../../util/db');
+const { coin } = require('../../util/random');
 
 const PPDB = process.env.PPDB || path.resolve('./ppdb-2.0-m-lexical.bin');
 const MAX_SPAN_LENGTH = 10;
 
 class QueryReadableAdapter extends Stream.Readable {
-    constructor(query) {
+    constructor(query, options) {
         super({ objectMode: true });
 
         query.on('result', (row) => {
             row.flags = parseFlags(row.flags);
             // mark a sentence for evaluation only if is exact and not synthetic,
             // which means it comes from the online dataset (developer data)
-            row.flags.eval = row.flags.exact && !row.flags.synthetic;
+
+            if (row.flags.exact && !row.flags.synthetic && coin(options.evalProbability, options.rng))
+                row.flags.eval = true;
+            else
+                row.flags.eval = false;
             row.flags.contextual = row.context !== null;
             this.push(row);
         });
@@ -131,7 +136,10 @@ class DatasetGenerator {
             order by id`;
 
         const query = this._dbClient.query(queryString, [this._language, this._forDevicesPattern]);
-        return new QueryReadableAdapter(query);
+        return new QueryReadableAdapter(query, {
+            evalProbability: this._options.evalProbability,
+            rng: this._rng
+        });
     }
 
     async _transaction() {
@@ -294,7 +302,9 @@ class DatasetGenerator {
             train,
             eval: eval_,
 
-            evalProbability: this._options.evalProbability,
+            // we use this._options.evalProbability to set the "eval" flag,
+            // but all sentences with the eval flag should go in the eval set
+            evalProbability: 1.0,
             forDevices: this._forDevices,
             splitStrategy: this._options.splitStrategy,
             useEvalFlag: true

--- a/training/tasks/prepare-training-set.js
+++ b/training/tasks/prepare-training-set.js
@@ -281,6 +281,7 @@ class DatasetGenerator {
             syntheticExpandFactor: 1,
             paraphrasingExpandFactor: 30,
             noQuoteExpandFactor: 10,
+            singleDeviceExpandFactor: 3,
 
             ppdbFile: ppdb,
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -52,9 +52,9 @@
     js-tokens "^4.0.0"
 
 "@babel/parser@^7.4.3", "@babel/parser@^7.4.4", "@babel/parser@^7.7.0", "@babel/parser@^7.7.2":
-  version "7.7.2"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.7.2.tgz#ea8334dc77416bfd9473eb470fd00d8245b3943b"
-  integrity sha512-DDaR5e0g4ZTb9aP7cpSZLkACEBdoLGwJDWgHtBhrGX7Q1RjhdoMOfexICj5cqTAtpowjGQWfcvfnQG7G2kAB5w==
+  version "7.7.3"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.7.3.tgz#5fad457c2529de476a248f75b0f090b3060af043"
+  integrity sha512-bqv+iCo9i+uLVbI0ILzKkvMorqxouI+GbV13ivcARXn9NNEabi2IEz912IgNpT/60BNXac5dgcfjb94NjsF33A==
 
 "@babel/template@^7.4.0", "@babel/template@^7.7.0":
   version "7.7.0"
@@ -265,14 +265,14 @@
   integrity sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw==
 
 "@types/node@*":
-  version "12.12.6"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.6.tgz#a47240c10d86a9a57bb0c633f0b2e0aea9ce9253"
-  integrity sha512-FjsYUPzEJdGXjwKqSpE0/9QEh6kzhTAeObA54rn6j3rR4C/mzpI9L0KNfoeASSPMMdxIsoJuCLDWcM/rVjIsSA==
+  version "12.12.7"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.7.tgz#01e4ea724d9e3bd50d90c11fd5980ba317d8fa11"
+  integrity sha512-E6Zn0rffhgd130zbCbAr/JdXfXkoOUFAKNs/rF8qnafSJ8KYaA/j3oz7dcwal+lYjLA7xvdd5J4wdYpCTlP8+w==
 
 "@types/node@^10.1.0", "@types/node@^10.12.0":
-  version "10.17.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.4.tgz#8993a4fe3c4022fda66bf4ea660d615fc5659c6f"
-  integrity sha512-F2pgg+LcIr/elguz+x+fdBX5KeZXGUOp7TV8M0TVIrDezYLFRNt8oMTyps0VQ1kj5WGGoR18RdxnRDHXrIFHMQ==
+  version "10.17.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.5.tgz#c1920150f7b90708a7d0f3add12a06bc9123c055"
+  integrity sha512-RElZIr/7JreF1eY6oD5RF3kpmdcreuQPjg5ri4oQ5g9sq7YWU8HkfB3eH8GwAwxf5OaCh0VPi7r4N/yoTGelrA==
 
 "@types/node@^9.4.6":
   version "9.6.55"
@@ -471,9 +471,9 @@ align-text@^0.1.1, align-text@^0.1.3:
     repeat-string "^1.5.2"
 
 almond-dialog-agent@~1.7.0:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/almond-dialog-agent/-/almond-dialog-agent-1.7.1.tgz#269723812c1f04b8bc669db8b8618cbe24f2a50a"
-  integrity sha512-XZBsPb14IKo/qfH1TOGPobd7F/25Lm5eekaJ5Tx8xK4Wu0YsVM9z6eUWk/KjJBKjIRum5uRy4rz0495YkYndLw==
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/almond-dialog-agent/-/almond-dialog-agent-1.7.2.tgz#ba78b5d0b489953fb1c3cd58c7e4b3172853b8ff"
+  integrity sha512-MIOFchS8nmAsknFo4TLiUd8tuDTjp4UcHcVDP38IocfwrJuztHs44a+HBVCgueSIOnSBOtCfrWS6CBMYiocwXg==
   dependencies:
     adt "^0.7.2"
     consumer-queue "^1.0.0"
@@ -508,6 +508,11 @@ ansi-regex@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
   integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
+
+ansi-regex@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
+  integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
 
 ansi-styles@^2.2.1:
   version "2.2.1"
@@ -729,9 +734,9 @@ atob@^2.1.1:
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
 aws-sdk@^2.2.48:
-  version "2.567.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.567.0.tgz#f5b96a2e461b3c6e760040cb5609b36cd0a36cb3"
-  integrity sha512-JGtO9QvOzOWmpgm/ErS82v6qHw2a4ObNa68eU1ivT+QtiqXPJOAFEBMj4dAu2KwLDr+XsljTRZd7b/7pZhXXNA==
+  version "2.569.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.569.0.tgz#a350583bd135d7106d2f92fb463df3239051361b"
+  integrity sha512-9i4n/8kR1cq+Ge1n9FzqEBE1kpF8uLEI24wssy0dQD1fks+eNoZ6b3bGMCR1OfYB0KVgIN7ZkUrng1Zu9M4fcA==
   dependencies:
     buffer "^4.9.1"
     events "^1.1.1"
@@ -1081,9 +1086,9 @@ buffer-xor@^1.0.3:
   integrity sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=
 
 buffer@^4.9.1:
-  version "4.9.1"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
-  integrity sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=
+  version "4.9.2"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8"
+  integrity sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
@@ -2003,9 +2008,9 @@ deps-sort@^2.0.0:
     through2 "^2.0.0"
 
 des.js@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.0.0.tgz#c074d2e2aa6a8a9a07dbd61f9a15c2cd83ec8ecc"
-  integrity sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.0.1.tgz#5382142e1bdc53f85d86d53e5f4aa7deb91e0843"
+  integrity sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==
   dependencies:
     inherits "^2.0.1"
     minimalistic-assert "^1.0.0"
@@ -2115,9 +2120,9 @@ doctypes@^1.1.0:
   integrity sha1-6oCxBqh1OHdOijpKWv4pPeSJ4Kk=
 
 dom-serializer@0:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.2.1.tgz#13650c850daffea35d8b626a4cfc4d3a17643fdb"
-  integrity sha512-sK3ujri04WyjwQXVoK4PU3y8ula1stq10GJZpqHIUgoGZdsGzAGu65BnU3d08aTVSvO7mGPZUc0wTEDL+qGE0Q==
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.2.2.tgz#1afb81f533717175d478655debc5e332d9f9bb51"
+  integrity sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==
   dependencies:
     domelementtype "^2.0.1"
     entities "^2.0.0"
@@ -2331,9 +2336,9 @@ es-abstract@^1.5.1:
     string.prototype.trimright "^2.1.0"
 
 es-to-primitive@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.0.tgz#edf72478033456e8dda8ef09e00ad9650707f377"
-  integrity sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.1.tgz#e55cd4c9cdc188bcefb03b366c736323fc5c898a"
+  integrity sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==
   dependencies:
     is-callable "^1.1.4"
     is-date-object "^1.0.1"
@@ -3102,9 +3107,9 @@ gcp-metadata@^1.0.0:
     json-bigint "^0.3.0"
 
 genie-toolkit@~0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/genie-toolkit/-/genie-toolkit-0.5.0.tgz#5c60ef49291c5af51a5620a2091fd0ba8f7b147d"
-  integrity sha512-ucGYfkVuzJcO7h7VOMVq7eZXdRvwjs8BDMsQYhZ8iC1eoRUNRXbdyYBdMp5Cm7ERIeu5rCDA+J/hM7jTuinjoQ==
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/genie-toolkit/-/genie-toolkit-0.5.1.tgz#595040cd189e7f46d76641badd41ad752c9f0c01"
+  integrity sha512-HRwkraNoZsh4fY2efUr03i3dZn6ynrDt8ff9KmPktD8u5QpQd6C9UHx436aLrxBYIqKL3vZPFhchRiTVEWWGYw==
   dependencies:
     argparse "^1.0.10"
     byline "^5.0.0"
@@ -5032,10 +5037,10 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
-mime-db@1.40.0:
-  version "1.40.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.40.0.tgz#a65057e998db090f732a68f6c276d387d4126c32"
-  integrity sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==
+mime-db@1.42.0:
+  version "1.42.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.42.0.tgz#3e252907b4c7adb906597b4b65636272cf9e7bac"
+  integrity sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ==
 
 mime-db@~1.25.0:
   version "1.25.0"
@@ -5050,11 +5055,11 @@ mime-types@2.1.13:
     mime-db "~1.25.0"
 
 mime-types@^2.1.12, mime-types@~2.1.19, mime-types@~2.1.24:
-  version "2.1.24"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.24.tgz#b6f8d0b3e951efb77dedeca194cff6d16f676f81"
-  integrity sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==
+  version "2.1.25"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.25.tgz#39772d46621f93e2a80a856c53b86a62156a6437"
+  integrity sha512-5KhStqB5xpTAeGqKBAMgwaYMnQik7teQN4IAzC7npDv6kzeU6prfkR67bc87J1kWMPGkoaZSq1npmexMgkmEVg==
   dependencies:
-    mime-db "1.40.0"
+    mime-db "1.42.0"
 
 mime@1.6.0:
   version "1.6.0"
@@ -5544,9 +5549,9 @@ object-hash@^1.3.1:
   integrity sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==
 
 object-inspect@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.6.0.tgz#c70b6cbf72f274aab4c34c0c82f5167bf82cf15b"
-  integrity sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.7.0.tgz#f4f6bd181ad77f006b5ece60bd0b6f398ff74a67"
+  integrity sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==
 
 object-inspect@~1.4.0:
   version "1.4.1"
@@ -7343,13 +7348,13 @@ string-width@^3.0.0, string-width@^3.1.0:
     strip-ansi "^5.1.0"
 
 string-width@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.1.0.tgz#ba846d1daa97c3c596155308063e075ed1c99aff"
-  integrity sha512-NrX+1dVVh+6Y9dnQ19pR0pP4FiEIlUvdTGn8pw6CKTNq5sgib2nIhmUNT5TAmhWmvKr3WcxBcP3E8nWezuipuQ==
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
+  integrity sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
   dependencies:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^5.2.0"
+    strip-ansi "^6.0.0"
 
 string.prototype.trimleft@^2.1.0:
   version "2.1.0"
@@ -7415,6 +7420,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532"
+  integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
+  dependencies:
+    ansi-regex "^5.0.0"
 
 strip-bom@^2.0.0:
   version "2.0.0"
@@ -7576,9 +7588,9 @@ thingpedia@~2.6.0:
     xml2js "^0.4.17"
 
 thingtalk@~1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/thingtalk/-/thingtalk-1.9.0.tgz#1caee484a69544d79b9f9f21af9e93c43c742284"
-  integrity sha512-7WoExlQt6NP/9SN5ViHBO2Qw8/zLSyOGk28TRT4u9igkb/uCKs7BMEdFgUEIBODeCfKBFQ0m3UsPsDZQrKBVOQ==
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/thingtalk/-/thingtalk-1.9.1.tgz#6dbebabb2cd350a8c61c408159e0f953c8ef0b03"
+  integrity sha512-gYrRToJhIISw9R9kv2B7xpUi/Htb8/M4Jg88EfmmLhBqsHfIuzqsk/0G5Nw9YuePLmgSYcyXBJwlnpO7MypDrQ==
   dependencies:
     adt "~0.7.2"
     byline "^5.0.0"


### PR DESCRIPTION
After https://github.com/stanford-oval/genie-toolkit/pull/117, setting
the eval flag disables augmentation, so we don't want to set it
unconditionally on all "online" & "commandpedia" sentences.
Instead, choose randomly which sentences are evaluation set (get the
eval flag) and which sentences are training. All sentences with
the "eval" flag then become evaluation set.

Fixes #582 