### PR TITLE
cloud-sync: add "await" in front of RPC calls

### DIFF
--- a/routes/cloud-sync.js
+++ b/routes/cloud-sync.js
@@ -1,0 +1,106 @@
+// -*- mode: js; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of ThingEngine
+//
+// Copyright 2015-2019 The Board of Trustees of the Leland Stanford Junior University
+//
+// Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
+//
+// See COPYING for details
+"use strict";
+
+const EngineManager = require('../almond/enginemanagerclient');
+
+class CloudSyncWebsocketDelegate {
+    constructor(ws) {
+        this._ws = ws;
+        this._remote = null;
+
+        ws.on('error', (err) => {
+            ws.close();
+        });
+        ws.on('close', async () => {
+            this.$free();
+        });
+    }
+
+    setRemote(remote) {
+        this._remote = remote;
+
+        this._ws.on('message', async (data) => {
+            try {
+                await remote.onMessage(data);
+            } catch(e) {
+                console.error('Failed to relay websocket message: ' + e.message);
+                this._ws.close();
+            }
+        });
+        this._ws.on('ping', async (data) => {
+            try {
+                await remote.onPing(data);
+            } catch(e) {
+                // ignore
+                this._ws.close();
+            }
+        });
+        this._ws.on('pong', async (data) => {
+            try {
+                await remote.onPong(data);
+            } catch(e) {
+                // ignore
+                this._ws.close();
+            }
+        });
+        this._ws.on('close', async (data) => {
+            try {
+                await remote.onClose(data);
+            } catch(e) {
+                // ignore
+            }
+            remote.$free();
+        });
+    }
+
+    ping() {
+        this._ws.ping();
+    }
+
+    pong() {
+        this._ws.pong();
+    }
+
+    send(data) {
+        this._ws.send(data);
+    }
+
+    terminate() {
+        this._ws.terminate();
+    }
+}
+CloudSyncWebsocketDelegate.prototype.$rpcMethods = ['ping', 'pong', 'terminate', 'send'];
+
+module.exports = {
+    async handle(ws, userId) {
+        try {
+            const engine = await EngineManager.get().getEngine(userId);
+
+            const onclosed = (id) => {
+                if (id === userId)
+                    ws.close();
+                EngineManager.get().removeListener('socket-closed', onclosed);
+            };
+            EngineManager.get().on('socket-closed', onclosed);
+
+            const delegate = new CloudSyncWebsocketDelegate(ws);
+            const remote = await engine.websocket.newConnection(delegate);
+            delegate.setRemote(remote);
+        } catch (error) {
+            console.error('Error in cloud-sync websocket: ' + error.message);
+
+            // ignore "Not Opened" error in closing
+            try {
+                ws.close();
+            } catch(e) {/**/}
+        }
+    }
+};

--- a/routes/my_api.js
+++ b/routes/my_api.js
@@ -23,6 +23,7 @@ const { makeRandom } = require('../util/random');
 
 const Config = require('../config');
 
+const CloudSync = require('./cloud-sync');
 const MyConversation = require('./my_conversation');
 
 var router = express.Router();
@@ -207,96 +208,8 @@ router.post('/apps/delete/:appId', user.requireScope('user-exec-command'), (req,
     }).catch(next);
 });
 
-class WebsocketDelegate {
-    constructor(ws) {
-        this._ws = ws;
-        this._remote = null;
-    }
-
-    setRemote(remote) {
-        this._remote = remote;
-
-        this._ws.on('message', (data) => {
-            try {
-                remote.onMessage(data);
-            } catch(e) {
-                console.error('Failed to relay websocket message: ' + e.message);
-                this._ws.close();
-            }
-        });
-        this._ws.on('ping', (data) => {
-            try {
-                remote.onPing(data);
-            } catch(e) {
-                // ignore
-                this._ws.close();
-            }
-        });
-        this._ws.on('pong', (data) => {
-            try {
-                remote.onPong(data);
-            } catch(e) {
-                // ignore
-                this._ws.close();
-            }
-        });
-        this._ws.on('close', (data) => {
-            try {
-                remote.onClose(data);
-            } catch(e) {
-                // ignore
-            }
-        });
-    }
-
-    ping() {
-        this._ws.ping();
-    }
-
-    pong() {
-        this._ws.pong();
-    }
-
-    send(data) {
-        this._ws.send(data);
-    }
-
-    terminate() {
-        this._ws.terminate();
-    }
-}
-WebsocketDelegate.prototype.$rpcMethods = ['ping', 'pong', 'terminate', 'send'];
-
-router.ws('/sync', user.requireScope('user-sync'), async (ws, req) => {
-    try {
-        const userId = req.user.id;
-        const engine = await EngineManager.get().getEngine(userId);
-
-        const onclosed = (id) => {
-            if (id === userId)
-                ws.close();
-            EngineManager.get().removeListener('socket-closed', onclosed);
-        };
-        EngineManager.get().on('socket-closed', onclosed);
-
-        const delegate = new WebsocketDelegate(ws);
-        ws.on('error', (err) => {
-            ws.close();
-        });
-        ws.on('close', async () => {
-            delegate.$free();
-        });
-
-        const remote = await engine.websocket.newConnection(delegate);
-        delegate.setRemote(remote);
-    } catch (error) {
-        console.error('Error in cloud-sync websocket: ' + error.message);
-
-        // ignore "Not Opened" error in closing
-        try {
-            ws.close();
-        } catch(e) {/**/}
-    }
+router.ws('/sync', user.requireScope('user-sync'), (ws, req) => {
+    CloudSync.handle(ws, req.user.id);
 });
 
 // if nothing handled the route, return a 404

--- a/routes/thingengine_ws.js
+++ b/routes/thingengine_ws.js
@@ -13,94 +13,22 @@ const express = require('express');
 
 const db = require('../util/db');
 const userModel = require('../model/user');
-const EngineManager = require('../almond/enginemanagerclient');
-const { NotFoundError } = require('../util/errors');
+
+const CloudSync = require('./cloud-sync');
 
 var router = express.Router();
 
-class WebsocketDelegate {
-    constructor(ws) {
-        this._ws = ws;
-        this._remote = null;
-    }
-
-    setRemote(remote) {
-        this._remote = remote;
-
-        this._ws.on('message', (data) => {
-            try {
-                remote.onMessage(data);
-            } catch(e) {
-                console.error('Failed to relay websocket message: ' + e.message);
-                this._ws.close();
-            }
-        });
-        this._ws.on('ping', (data) => {
-            try {
-                remote.onPing(data);
-            } catch(e) {
-                // ignore
-                this._ws.close();
-            }
-        });
-        this._ws.on('pong', (data) => {
-            try {
-                remote.onPong(data);
-            } catch(e) {
-                // ignore
-                this._ws.close();
-            }
-        });
-        this._ws.on('close', (data) => {
-            try {
-                remote.onClose(data);
-            } catch(e) {
-                // ignore
-            }
-        });
-    }
-
-    ping() {
-        this._ws.ping();
-    }
-
-    pong() {
-        this._ws.pong();
-    }
-
-    send(data) {
-        this._ws.send(data);
-    }
-
-    terminate() {
-        this._ws.terminate();
-    }
-}
-WebsocketDelegate.prototype.$rpcMethods = ['ping', 'pong', 'terminate', 'send'];
 
 router.ws('/:cloud_id', (ws, req) => {
     db.withClient((dbClient) => {
         return userModel.getByCloudId(dbClient, req.params.cloud_id);
     }).then((rows) => {
-        if (rows.length === 0)
-            throw new NotFoundError();
+        if (rows.length === 0) {
+            ws.close();
+            return;
+        }
 
-        return Promise.all([rows[0].id, EngineManager.get().getEngine(rows[0].id)]);
-    }).then(([id, engine]) => {
-        const onclosed = (userId) => {
-            if (userId === id)
-                ws.close();
-            EngineManager.get().removeListener('socket-closed', onclosed);
-        };
-        EngineManager.get().on('socket-closed', onclosed);
-
-        var delegate = new WebsocketDelegate(ws);
-        return engine.websocket.newConnection(delegate).then((remote) => {
-            delegate.setRemote(remote);
-        });
-    }).catch((error) => {
-        console.error('Error in ThingEngine websocket: ' + error.message);
-        ws.close();
+        CloudSync.handle(ws, rows[0].id);
     });
 });
 


### PR DESCRIPTION
So async errors are caught correctly. Also, consolidate the two
copies of the same code into one module.

Fixes #617