### PR TITLE
Remove UI to request device reviews

### DIFF
--- a/routes/thingpedia_devices.js
+++ b/routes/thingpedia_devices.js
@@ -14,8 +14,6 @@ const express = require('express');
 
 const ThingTalk = require('thingtalk');
 
-const Config = require('../config');
-
 const db = require('../util/db');
 const model = require('../model/device');
 const user = require('../util/user');
@@ -23,7 +21,6 @@ const schemaModel = require('../model/schema');
 const exampleModel = require('../model/example');
 const trainingJobModel = require('../model/training_job');
 const TrainingServer = require('../util/training_server');
-const SendMail = require('../util/sendmail');
 const I18n = require('../util/i18n');
 const tokenize = require('../util/tokenize');
 const creditSystem = require('../util/credit_system');
@@ -330,29 +327,6 @@ router.post('/train', iv.validatePOST({ kind: 'string' }), (req, res, next) => {
 
         return TrainingServer.get().queue('en', [req.body.kind], 'train');
     }).then(() => {
-        res.redirect(303, '/thingpedia/devices/by-id/' + req.body.kind);
-    }).catch(next);
-});
-
-router.post('/request-approval', iv.validatePOST({ kind: 'string', comments: '?string' }), (req, res, next) => {
-    var mailOptions = {
-        from: Config.EMAIL_FROM_ADMIN,
-        to: Config.EMAIL_TO_ADMIN,
-        subject: `Review Request for ${req.body.kind}`,
-        replyTo: {
-            name: req.user.human_name,
-            address: req.user.email
-        },
-        text:
-`${req.user.human_name} (${req.user.username}) requests a review of ${req.body.kind}.
-Link: https://almond.stanford.edu/thingpedia/devices/by-id/${req.body.kind}
-
-Comments:
-${(req.body.comments || '').trim()}
-`
-    };
-
-    SendMail.send(mailOptions).then(() => {
         res.redirect(303, '/thingpedia/devices/by-id/' + req.body.kind);
     }).catch(next);
 });

--- a/views/thingpedia_device_details.pug
+++ b/views/thingpedia_device_details.pug
@@ -27,9 +27,7 @@ block content
             | &#x20;
             button(type='submit').btn.btn-success= _("Approve it")
       else if authenticated && user.developer_org === device.owner
-        p= _("This device is not yet approved for general use.")
-          | &#x20;
-          a(href='#request-approval-container',data-toggle='collapse',aria-expanded='false',aria-controls='request-approval-container').btn.btn-default= _("Request approval")
+        p= _("This device is not yet approved for general use. Please open a new topic in the community forum if you would like to have it reviewed.")
       else
         p= _("This device is not yet approved for general use. You need a developer key to use it.")
   else if device.approved_version !== device.developer_version && authenticated && (user.roles & Constants.Role.THINGPEDIA_ADMIN) !== 0
@@ -40,22 +38,6 @@ block content
         p.form-group= _("A newer version of this device was submitted.")
           | &#x20;
           button(type='submit').btn.btn-success= _("Approve it")
-
-  div#request-approval-container.collapse
-    div.panel.panel-default
-      p.panel-heading= _("Request Approval")
-
-      div.panel-body
-        form(action='/thingpedia/devices/request-approval', method='post', data-toggle='validator')
-          input(type='hidden',name='_csrf',value=csrfToken)
-          input(type='hidden',name='kind',value=device.primary_kind)
-        
-          div.form-group
-            label(for='request-approval-comments').control-label= _("Additional comments (optional)")
-            textarea(name='comments').form-control#request-approval-comments
-
-          div.form-group
-            button(type='submit').btn.btn-primary= _("Send Request")
 
   if !device.translated
     div.alert.alert-info(role='alert')


### PR DESCRIPTION
Point people to the community forum, which is a better interface
for reviews than emails. This should reduce accidental use of the UI,
and force people to write something in the comment field.

Fixes #618