### PR TITLE
training: do not compute ETA for tasks with unreliable progress

### DIFF
--- a/training/job_specs.js
+++ b/training/job_specs.js
@@ -22,6 +22,7 @@ module.exports = {
         {
             name: 'update-dataset',
             progress: 0.9,
+            computeEta: false,
 
             requests: {
                 cpu: 1.1,
@@ -31,6 +32,7 @@ module.exports = {
         {
             name: 'reloading-exact',
             progress: 0.1,
+            computeEta: false,
 
             async task(job) {
                 // reload the exact matches now that the synthetic set has been updated
@@ -49,6 +51,7 @@ module.exports = {
         {
             name: 'prepare-training-set',
             progress: 0.15,
+            computeEta: false,
 
             requests: {
                 cpu: 1.5,
@@ -58,6 +61,7 @@ module.exports = {
         {
             name: 'train',
             progress: 0.8,
+            computeEta: true,
 
             requests: {
                 cpu: 2.5,
@@ -67,6 +71,7 @@ module.exports = {
         {
             name: 'evaluate',
             progress: 0.049,
+            computeEta: false,
 
             requests: {
                 cpu: 1.5,
@@ -76,6 +81,7 @@ module.exports = {
         {
             name: 'uploading',
             progress: 0.001,
+            computeEta: false,
 
             async task(job) {
                 const modelLangDir = `./${job.model_tag}:${job.language}`;


### PR DESCRIPTION
Progress for Genie generation tasks is not very uniform, because
it depends on manually tuned heuristic coefficients, so the ETA
that is computed is meaningless. Instead, do not compute it at all.

Fixes #598 