### PR TITLE
Update example Kubernetes documentation

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,12 @@ USER root
 
 # add all the repos: epel (for GraphicsMagick), yarn, sqlcipher, bubblewrap,
 # then install the packages needed at runtime
-RUN curl -sL https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm -o epel-release-latest-8.noarch.rpm && \
+#
+# "touch" is a workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1213602
+# (https://github.com/moby/moby/issues/10180)
+# which apparently still exists and is causing failures on the dockerhub autobuilds
+RUN touch /var/lib/rpm/* && \
+  curl -sL https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm -o epel-release-latest-8.noarch.rpm && \
   dnf -y install epel-release-latest-8.noarch.rpm && \
   curl -sL https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo && \
   curl -sL https://copr.fedorainfracloud.org/coprs/gcampax/sqlcipher/repo/epel-8/gcampax-sqlcipher-epel-8.repo -o /etc/yum.repos.d/gcampax-sqlcipher-epel-8.repo && \
@@ -28,7 +33,8 @@ RUN mkdir -p /usr/local/share/almond-cloud/classifier && \
     curl -sL https://nnmaster.almond.stanford.edu/test-models/classifier1.tar.gz -o classifier1.tar.gz && \
     tar xvf classifier1.tar.gz -C /usr/local/share/almond-cloud/classifier && \
     rm -f classifier1.tar.gz
-RUN dnf -y install gcc gcc-c++ && \
+RUN touch /var/lib/rpm/* && \
+    dnf -y install gcc gcc-c++ && \
     pip3 install wheel && \
     pip3 install pytorch_transformers==1.2.0 tensorboardX tqdm && \
     rm -fr /root/.cache && \
@@ -45,7 +51,8 @@ WORKDIR /opt/almond-cloud/
 RUN echo "build_from_source true" > .yarnrc && echo "sqlite_libname sqlcipher" >> .yarnrc
 
 # install build dependencies and build
-RUN dnf -y install make gettext python27 yarn gcc gcc-c++ sqlcipher-devel && \
+RUN touch /var/lib/rpm/* && \
+  dnf -y install make gettext python27 yarn gcc gcc-c++ sqlcipher-devel && \
   alternatives --set python /usr/bin/python2 && \
   yarn install && \
   dnf -y remove make gettext python27 yarn gcc gcc-c++ sqlcipher-devel && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@ RUN curl -sL https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.
   curl -sL https://copr.fedorainfracloud.org/coprs/gcampax/sqlcipher/repo/epel-8/gcampax-sqlcipher-epel-8.repo -o /etc/yum.repos.d/gcampax-sqlcipher-epel-8.repo && \
   curl -sL https://copr.fedorainfracloud.org/coprs/gcampax/bubblewrap/repo/epel-8/gcampax-bubblewrap-epel-8.repo -o /etc/yum.repos.d/gcampax-bubblewrap-epel-8.repo && \
   dnf module install -y nodejs:10 && \
-  dnf -y install unzip GraphicsMagick bubblewrap sqlcipher sqlcipher-devel && \
+  dnf -y install unzip GraphicsMagick bubblewrap sqlcipher sqlcipher-devel mariadb procps-ng && \
   rm -rf /var/cache/dnf
 
 # install aws client
@@ -57,4 +57,4 @@ RUN useradd -ms /bin/bash -r almond-cloud
 USER almond-cloud
 WORKDIR /home/almond-cloud
 
-ENTRYPOINT ["/bin/bash", "/opt/almond-cloud/docker/start.sh"]
+ENTRYPOINT ["/opt/almond-cloud/docker/start.sh"]

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-set -x
 NODE_MAX_OLD_SPACE_SIZE=${NODE_MAX_OLD_SPACE_SIZE:-500}
 exec node --max_old_space_size=${NODE_MAX_OLD_SPACE_SIZE} /opt/almond-cloud/main.js "$@"

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -8,20 +8,100 @@ The files in this folder are an *example* only. Actually deploying Almond
 Cloud requires site-specific configuration. Please refer to the
 documentation for details.
 
-## nlp.yaml
+## Installing the examples
+
+For quick testing and development, it is possible to install the examples
+in an existing Kubernetes cluster. **This is only tested in minikube, and not supported
+in production.**
+
+To install, use the following steps:
+
+### Step 1: install the database
+
+```bash
+kubectl apply -f mysql.yaml
+```
+
+You can skip this step if you have a existing mysql installation in the cluster. In
+that case, change the `DATABASE_URL` key in the configmap you'll choose in the next step.
+
+### Step 2: configure
+
+```
+kubectl apply -f web-almond-config.yaml
+```
+
+This install Web Almond only, running against the public NLP and Thingpedia servers.
+Other configurations might be added in the future.
+
+### Step 3: bootstrap
+
+```
+kubectl apply -f bootstrap.yaml
+```
+
+This will run a job called `almond-bootstrap` that will bootstrap the Almond installation.
+You should wait until the job completes before proceeding further.
+
+### Step 4: run
+
+```
+kubectl apply -f backend.yaml -f frontend.yaml
+```
+
+## Available Kubernetes files
+
+### mysql.yaml
+
+A simple mysql deployment, lifted from the Kubernetes documentation. The root password is
+`passwordpasswordpassword`. Needless to say, you should change that if the cluster is accessible
+outside of a testing environment, or if the database will ever contain real data.
+
+### web-almond-config.yaml
+
+ConfigMap containing the configuration of Almond. This configuration enables Web Almond only,
+running against the public NLP and Thingpedia servers.
+
+The list of configuration keys is available at <https://almond.stanford.edu/doc/almond-config-file-reference.md>.
+
+The configuration is provided as a configmap to simplify the examples, but because some
+of the keys are security sensitive, it is likely better provided as a secret.
+
+### backend.yaml
+
+The file deploys an Almond backend, as a stateful set. Each replica of the stateful set
+is assigned its own private storage (using a persistent volume claim) and runs a different
+shard of users.
+
+You cannot change the number of replicas after deployment. You should choose it ahead of time,
+and adjust the `THINGENGINE_MANAGER_ADDRESS` key in the configuration accordingly.
+
+Note that sandboxing is disabled in this example configuration. Sandboxing is not yet compatible
+with running the backend in Kubernetes.
+
+### frontend.yaml
+
+The file deploys an Almond web frontend. The Almond frontend is a simple stateless server,
+and it is accessible as the service "almond-frontend" forwarding port 8080.
+
+The file also deploys an Ingress, with no host configured. On minikube, you should run
+```bash
+minikube addons enable ingress
+```
+to install an ingress controller and expose the frontend.
+
+### nlp.yaml
 
 This file deploys an NLP inference server, and configures a service "nlp" forwarding
 port 8400. It also deploys a replicated tokenizer server, listening at the service
 "tokenizer", port 8888.
-The NLP server must be configured to talk to the tokenizer server in the
-config.js (not provided).
 
-Quite likely, the NLP server should be exposed outside of the cluster with an Ingress.
-Ingress configuration is not provided because the syntax depends on the ingress
-controller used (ALB or nginx).
+The NLP server must be enabled and configured separately in the almond-config configmap.
+Additionally, you will need to obtain a pretrained model, or obtain a dataset and
+deploy a training service on a GPU-enabled machine.
 
-## training.yaml
+### training.yaml
 
 This file deploys a training controller server, with a corresponding service "training"
-forwarding port 8090. A companion server is also provided in `gpu-training.yaml`, for
-the GPU-specific parts of the training process.
+forwarding port 8090.
+

--- a/k8s/backend.yaml
+++ b/k8s/backend.yaml
@@ -1,0 +1,74 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: almond-backend
+  labels:
+    app: almond-backend
+spec:
+  ports:
+  - port: 8100
+    protocol: TCP
+  clusterIP: None
+  selector:
+    app: almond-backend
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: "almond-backend"
+spec:
+  selector:
+    matchLabels:
+      app: "almond-backend"
+  replicas: 2
+  serviceName: almond-backend
+  template:
+    metadata:
+      labels:
+        app: "almond-backend"
+    spec:
+      containers:
+      - name: "main"
+        image: stanfordoval/almond-cloud:latest
+        env:
+        - name: THINGENGINE_DISABLE_SANDBOX
+          value: "1"
+        command:
+        - bash
+        - "-c"
+        - |
+          set -ex
+          # Generate shard number from pod ordinal index.
+          [[ `hostname` =~ -([0-9]+)$ ]] || exit 1
+          ordinal=${BASH_REMATCH[1]}
+          exec /opt/almond-cloud/docker/start.sh run-almond --shard "${ordinal}"
+        volumeMounts:
+        - name: almond-user-data
+          mountPath: "/srv/thingengine"
+          readOnly: false
+        - name: config
+          mountPath: "/etc/almond-cloud"
+          readOnly: true
+        resources:
+          requests:
+            memory: 200M
+        ports:
+          - containerPort: 8100
+            name: almond
+        readinessProbe:
+          tcpSocket:
+            port: 8100
+          periodSeconds: 20
+      volumes:
+      - name: config
+        secret:
+          secretName: almond-config
+  volumeClaimTemplates:
+  - metadata:
+      name: almond-user-data
+    spec:
+      accessModes:
+        - ReadWriteMany
+      resources:
+        requests:
+          storage: 2G

--- a/k8s/backend.yaml
+++ b/k8s/backend.yaml
@@ -33,15 +33,8 @@ spec:
         env:
         - name: THINGENGINE_DISABLE_SANDBOX
           value: "1"
-        command:
-        - bash
-        - "-c"
-        - |
-          set -ex
-          # Generate shard number from pod ordinal index.
-          [[ `hostname` =~ -([0-9]+)$ ]] || exit 1
-          ordinal=${BASH_REMATCH[1]}
-          exec /opt/almond-cloud/docker/start.sh run-almond --shard "${ordinal}"
+        args: ["run-almond", "--k8s"]
+        workingDir: /srv/thingengine
         volumeMounts:
         - name: almond-user-data
           mountPath: "/srv/thingengine"

--- a/k8s/bootstrap.yaml
+++ b/k8s/bootstrap.yaml
@@ -1,0 +1,42 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: almond-bootstrap
+  labels:
+    app: almond-bootstrapper
+
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 0
+
+  template:
+    metadata:
+      labels:
+        app: almond-bootstrapper
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: main
+        image: stanfordoval/almond-cloud:latest
+        env:
+        - name: MYSQL_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mysql-root-password
+              key: MYSQL_ROOT_PASSWORD
+        command:
+        - sh
+        - "-c"
+        - |
+          mysql -h mysql -u root -p$MYSQL_ROOT_PASSWORD \
+            "create database if not exists almond; grant all privileges on almond.* to 'almond'@'%' identified by 'almond';";
+          /opt/almond-cloud/docker/start.sh bootstrap
+        volumeMounts:
+        - name: config
+          mountPath: "/etc/almond-cloud"
+          readOnly: true
+      volumes:
+      - name: config
+        secret:
+          secretName: almond-config

--- a/k8s/frontend.yaml
+++ b/k8s/frontend.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "almond-frontend"
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: "almond-frontend"
+  template:
+    metadata:
+      labels:
+        app: "almond-frontend"
+    spec:
+      containers:
+      - name: "main"
+        image: stanfordoval/almond-cloud:latest
+        args: ["run-frontend"]
+        volumeMounts:
+        - name: config
+          mountPath: "/etc/almond-cloud"
+          readOnly: true
+        resources:
+          requests:
+            memory: 8G
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 20
+      volumes:
+      - name: config
+        secret:
+          secretName: almond-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: almond-frontend
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+  selector:
+    app: almond-frontend
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: almond-frontend
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /
+        backend:
+          serviceName: almond-frontend
+          servicePort: 8080
+

--- a/k8s/mysql.yaml
+++ b/k8s/mysql.yaml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+spec:
+  ports:
+  - port: 3306
+  selector:
+    app: mysql
+  clusterIP: None
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql
+spec:
+  selector:
+    matchLabels:
+      app: mysql
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: mysql
+    spec:
+      containers:
+      - image: mariadb:10.2
+        name: mysql
+        env:
+        - name: MYSQL_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mysql-root-password
+              key: MYSQL_ROOT_PASSWORD
+        ports:
+        - containerPort: 3306
+          name: mysql
+        volumeMounts:
+        - name: mysql-persistent-storage
+          mountPath: /var/lib/mysql
+      volumes:
+      - name: mysql-persistent-storage
+        persistentVolumeClaim:
+          claimName: mysql-pv-claim
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mysql-pv-claim
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysql-root-password
+data:
+  MYSQL_ROOT_PASSWORD: cGFzc3dvcmRwYXNzd29yZHBhc3N3b3Jk

--- a/k8s/web-almond-config.yaml
+++ b/k8s/web-almond-config.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: almond-config
+data:
+  config.yaml: |
+    SERVER_ORIGIN: 'http://127.0.0.1:8888'
+    ENABLE_REDIRECT: false
+    # no https in this example configuration
+    ENABLE_SECURITY_HEADERS: false
+    WITH_THINGPEDIA: external
+    THINGPEDIA_URL: 'https://thingpedia.stanford.edu/thingpedia'
+    NL_SERVER_URL: 'https://almond-nl.stanford.edu'
+    ENABLE_ANONYMOUS_USER: true
+    ENABLE_PROMETHEUS: true
+    ENABLE_DEVELOPER_PROGRAM: false
+    THINGENGINE_MANAGER_ADDRESS:
+      - almond-backend-0.almond-backend.default.svc.cluster.local:8100
+      - almond-backend-1.almond-backend.default.svc.cluster.local:8100
+    # these are just examples, and should be replaced with real secrets!
+    # also, in production you'll likely want to use a secret not a confg map
+    THINGENGINE_MANAGER_AUTHENTICATION: ca2398e40ffdb53426d6a6b8ac2041a25efa2b8bfcc820339a3c133dd301b909
+    AES_SECRET_KEY: 80bb23f93126074ba01410c8a2278c0c
+    JWT_SIGNING_KEY: c744910b52f2653790e276fdf55c5181ddd374853a5afdc756532ab586ad9318
+    SECRET_KEY: 1be7cf23cf1b66320359a493067b815685a67df509f76be9a8823d4798eddc1a
+    # you should probably change this one too
+    DATABASE_URL: mysql://almond:almond@mysql/almond

--- a/scripts/execute-sql-file.js
+++ b/scripts/execute-sql-file.js
@@ -9,12 +9,7 @@
 // See COPYING for details
 "use strict";
 
-const child_process = require('child_process');
-const Url = require('url');
-const util = require('util');
-const fs = require('fs');
-
-const Config = require('../config');
+const execSql = require('../util/exec_sql');
 
 module.exports = {
     initArgparse(subparsers) {
@@ -28,31 +23,7 @@ module.exports = {
 
     async main(argv) {
         try {
-            const parsed = Url.parse(Config.DATABASE_URL);
-            const [user, pass] = parsed.auth.split(':');
-
-            const args = [
-                '-h', parsed.hostname,
-                '-u', user,
-                '-p' + pass,
-                '-D', parsed.pathname.substring(1),
-                '--batch'
-            ];
-
-            const stdin = argv.filename === '-' ? 'inherit' :
-                await util.promisify(fs.open)(argv.filename, 'r');
-            const child = child_process.spawn('mysql', args, {
-                stdio: [stdin, 'inherit', 'inherit'],
-            });
-            process.exit(await new Promise((resolve, reject) => {
-                child.on('exit', (code, signal) => {
-                    if (signal)
-                        reject(new Error(`Crashed with signal ${signal}`));
-                    else
-                        resolve(code);
-                });
-                child.on('error', reject);
-            }));
+            execSql.exec(argv.filename);
         } catch(e) {
             console.error(e);
             process.exit(1);

--- a/tests/nlp-integration.sh
+++ b/tests/nlp-integration.sh
@@ -69,8 +69,7 @@ mkdir -p $workdir/shared/cache
 echo '{"tt:stock_id:goog": "fb80c6ac2685d4401806795765550abdce2aa906.png"}' > $workdir/shared/cache/index.json
 
 # clean the database and bootstrap
-${srcdir}/main.js execute-sql-file $srcdir/model/schema.sql
-${srcdir}/main.js bootstrap
+${srcdir}/main.js bootstrap --force
 
 mkdir -p 'models/org.thingpedia.models.default:en'
 mkdir -p 'models/org.thingpedia.models.contextual:en'

--- a/tests/thingpedia-integration.sh
+++ b/tests/thingpedia-integration.sh
@@ -69,8 +69,7 @@ echo '{"tt:stock_id:goog": "fb80c6ac2685d4401806795765550abdce2aa906.png"}' > $w
 # clean the database and bootstrap
 # (this has to occur after setting up the download
 # directories because it copies the icon png files)
-${srcdir}/main.js execute-sql-file $srcdir/model/schema.sql
-${srcdir}/main.js bootstrap
+${srcdir}/main.js bootstrap --force
 
 # load some more data into Thingpedia
 test -f $srcdir/tests/data/com.bing.zip || wget https://thingpedia.stanford.edu/thingpedia/download/devices/com.bing.zip -O $srcdir/tests/data/com.bing.zip

--- a/tests/training-integration.sh
+++ b/tests/training-integration.sh
@@ -94,8 +94,7 @@ echo '{"tt:stock_id:goog": "fb80c6ac2685d4401806795765550abdce2aa906.png"}' > $w
 # clean the database and bootstrap
 # (this has to occur after setting up the download
 # directories because it copies the icon png files)
-${srcdir}/main.js execute-sql-file $srcdir/model/schema.sql
-${srcdir}/main.js bootstrap
+${srcdir}/main.js bootstrap --force
 
 # load some more data into Thingpedia
 test -f $srcdir/tests/data/com.bing.zip || wget https://thingpedia.stanford.edu/thingpedia/download/devices/com.bing.zip -O $srcdir/tests/data/com.bing.zip

--- a/tests/webalmond-integration.sh
+++ b/tests/webalmond-integration.sh
@@ -34,8 +34,7 @@ module.exports.DISCOURSE_SSO_REDIRECT = 'https://discourse.almond.stanford.edu';
 EOF
 
 # clean the database and bootstrap
-${srcdir}/main.js execute-sql-file $srcdir/model/schema.sql
-eval $(${srcdir}/main.js bootstrap)
+${srcdir}/main.js bootstrap --force
 
 workdir=`mktemp -t -d webalmond-integration-XXXXXX`
 workdir=`realpath $workdir`

--- a/util/exec_sql.js
+++ b/util/exec_sql.js
@@ -1,0 +1,51 @@
+// -*- mode: js; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of ThingEngine
+//
+// Copyright 2018 The Board of Trustees of the Leland Stanford Junior University
+//
+// Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
+//
+// See COPYING for details
+"use strict";
+
+const child_process = require('child_process');
+const Url = require('url');
+const util = require('util');
+const fs = require('fs');
+
+const Config = require('../config');
+
+module.exports = {
+    async exec(filename) {
+        const parsed = Url.parse(Config.DATABASE_URL);
+        const [user, pass] = parsed.auth.split(':');
+
+        const args = [
+            '-h', parsed.hostname,
+            '-u', user,
+            '-p' + pass,
+            '-D', parsed.pathname.substring(1),
+            '--batch'
+        ];
+
+        const stdin = filename === '-' ? 'inherit' :
+            await util.promisify(fs.open)(filename, 'r');
+        const child = child_process.spawn('mysql', args, {
+            stdio: [stdin, 'inherit', 'inherit'],
+        });
+
+        await new Promise((resolve, reject) => {
+            child.on('exit', (code, signal) => {
+                if (signal)
+                    reject(new Error(`Crashed with signal ${signal}`));
+                else
+                    resolve(code);
+            });
+            child.on('error', reject);
+        });
+
+        if (stdin !== 'inherit')
+            await util.promisify(fs.close)(stdin);
+    }
+};


### PR DESCRIPTION
We can make [minikube](https://minikube.sigs.k8s.io/) the simplest way to quick-start an Almond cloud installation for testing (other than the CI test scripts)