### PR TITLE
cloud-sync: fix race condition resulting in stuck connections

### DIFF
--- a/routes/my_api.js
+++ b/routes/my_api.js
@@ -209,7 +209,7 @@ router.post('/apps/delete/:appId', user.requireScope('user-exec-command'), (req,
 });
 
 router.ws('/sync', user.requireScope('user-sync'), (ws, req) => {
-    CloudSync.handle(ws, req.user.id);
+    CloudSync.handle(ws).setUser(req.user.id);
 });
 
 // if nothing handled the route, return a 404

--- a/routes/thingengine_ws.js
+++ b/routes/thingengine_ws.js
@@ -20,6 +20,8 @@ var router = express.Router();
 
 
 router.ws('/:cloud_id', (ws, req) => {
+    const delegate = CloudSync.handle(ws);
+
     db.withClient((dbClient) => {
         return userModel.getByCloudId(dbClient, req.params.cloud_id);
     }).then((rows) => {
@@ -28,7 +30,7 @@ router.ws('/:cloud_id', (ws, req) => {
             return;
         }
 
-        CloudSync.handle(ws, rows[0].id);
+        delegate.setUser(rows[0].id);
     });
 });
 


### PR DESCRIPTION
We must begin processing messages on the websocket as soon as we
receive the websocket connection, rather than after retrieving
the user from the database, otherwise some messages might be
dropped. To do so, we need to buffer all incoming messages until
the backend is ready to process them.
(In the future, it will make more sense for the server to send
a "hello" message in the web socket first. But this is what we
have so far. Lessons learned!)

This is a fix that has been in staging for a while, but I forgot to push it.
