### PR TITLE
Allow debugging synthetic generation inside the sandbox

### DIFF
--- a/training/backends/kubernetes.js
+++ b/training/backends/kubernetes.js
@@ -227,10 +227,10 @@ module.exports = async function execTask(job, spec) {
                             resources: {
                                 requests: {
                                     cpu: spec.cpu,
-                                    memory: (Config.TRAINING_MEMORY_USAGE + 100) + 'Mi'
+                                    memory: (Config.TRAINING_MEMORY_USAGE + 500) + 'Mi'
                                 },
                                 limits: {
-                                    memory: (Config.TRAINING_MEMORY_USAGE + 100) + 'Mi'
+                                    memory: (Config.TRAINING_MEMORY_USAGE + 500) + 'Mi'
                                 }
                             },
                             securityContext: {

--- a/training/backends/kubernetes.js
+++ b/training/backends/kubernetes.js
@@ -228,6 +228,9 @@ module.exports = async function execTask(job, spec) {
                                 requests: {
                                     cpu: spec.cpu,
                                     memory: (Config.TRAINING_MEMORY_USAGE + 100) + 'Mi'
+                                },
+                                limits: {
+                                    memory: (Config.TRAINING_MEMORY_USAGE + 100) + 'Mi'
                                 }
                             },
                             securityContext: {


### PR DESCRIPTION
Previously, debugging was disabled cause it would conflict with
the generation of the dataset on standard output. But we can
generate the dataset in a different file descriptor and still
get debug output.