### PR TITLE
me/status: allow testers to see the developer logs

### DIFF
--- a/routes/status.js
+++ b/routes/status.js
@@ -77,7 +77,7 @@ router.get('/', (req, res, next) => {
     }).catch(next);
 });
 
-router.get('/logs', user.requireDeveloper(), iv.validateGET({ startCursor: '?string' }), (req, res) => {
+router.get('/logs', user.requireDeveloper(user.DeveloperStatus.USER), iv.validateGET({ startCursor: '?string' }), (req, res) => {
     var child = readLogs(req.user.id, req.query.startCursor);
     var stdout = child.stdout;
     res.set('Content-Type', 'text/event-stream');


### PR DESCRIPTION
Testers have a developer account but a developer status of 0
(they can see the private devices but not update them). That is
enough to let them see their own logs.