### PR TITLE
nlp: serve contextual and non-contextual models correctly

### DIFF
--- a/nlp/nlp_model.js
+++ b/nlp/nlp_model.js
@@ -136,6 +136,7 @@ module.exports = class NLPModel {
         this.tag = spec.tag;
         this.locale = spec.language;
         this.trained = spec.trained;
+        this.contextual = spec.contextual;
 
         if (spec.use_exact)
             this.exact = service.getExact(spec.language);

--- a/nlp/nlu.js
+++ b/nlp/nlu.js
@@ -42,6 +42,14 @@ async function runNLU(query, params, data, service, res) {
             res.status(404).json({ error: 'No such model' });
             return undefined;
         }
+
+        if (model.contextual && !data.context) {
+            data.context = 'null';
+            data.entities = {};
+        } else if (!model.contextual) {
+            data.context = undefined;
+            data.entities = undefined;
+        }
     } else {
         let fallbacks;
         if (isValidDeveloperKey(data.developer_key)) {
@@ -65,11 +73,10 @@ async function runNLU(query, params, data, service, res) {
         for (const candidate of fallbacks) {
             model = service.getModel(candidate, params.locale);
             if (model && model.trained) {
-                const isContextual = candidate.endsWith('.contextual');
-                if (isContextual && !data.context) {
+                if (model.contextual && !data.context) {
                     data.context = 'null';
                     data.entities = {};
-                } else if (!isContextual) {
+                } else if (!model.contextual) {
                     data.context = undefined;
                     data.entities = undefined;
                 }


### PR DESCRIPTION
So we can use the non-contextual API endpoint to query contextual
models, which is convenient to test things.