### PR TITLE
Store the context of each request in the utterance log

### DIFF
--- a/model/migrations/c953506-log_context.sql
+++ b/model/migrations/c953506-log_context.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `utterance_log`
+  ADD `context` text NULL AFTER `language`;

--- a/model/schema.sql
+++ b/model/schema.sql
@@ -797,6 +797,7 @@ DROP TABLE IF EXISTS `utterance_log`;
 CREATE TABLE `utterance_log` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `language` char(15) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT 'en',
+  `context` text NULL,
   `preprocessed` text NOT NULL,
   `target_code` text CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
   `time` datetime DEFAULT current_timestamp(),

--- a/nlp/nlu.js
+++ b/nlp/nlu.js
@@ -102,6 +102,7 @@ async function runNLU(query, params, data, service, res) {
             return exampleModel.logUtterance(dbClient, {
                 language: model.locale,
                 preprocessed: tokens.join(' '),
+                context: (!data.context || data.context === 'null') ? null : data.context,
                 target_code: candidates.length > 0 ? (candidates[0]['code'].join(' ')) : ''
             });
         });


### PR DESCRIPTION
So we don't have to drop all contextual commands when we analyze the log.