### PR TITLE
Fix querying setup information for Home Assistant switches

### DIFF
--- a/model/device.js
+++ b/model/device.js
@@ -446,13 +446,13 @@ module.exports = {
                  from device_class d, device_code_version dcv where d.id = dcv.device_id and
                  dcv.version = d.developer_version
                  and d.primary_kind in (?))
-                union all
+                union distinct
                 (select d.primary_kind, d.name, d.category, dck.kind as for_kind, dcv.code, dcv.factory from device_class d,
                  device_code_version dcv, device_class_kind dck where dck.device_id = d.id and
                  d.id = dcv.device_id and
                  dcv.version = d.developer_version
                  and dck.kind in (?))
-                union all
+                union distinct
                 (select d.primary_kind, d.name, d.category, dck2.kind as for_kind, dcv.code, dcv.factory from device_class d,
                  device_class d2, device_class_kind dck2, device_code_version dcv, device_class_kind dck
                  where dck.device_id = d.id and d.id = dcv.device_id and
@@ -466,14 +466,14 @@ module.exports = {
                  ((dcv.version = d.developer_version and d.owner = ?) or
                   (dcv.version = d.approved_version and d.owner <> ?))
                  and d.primary_kind in (?))
-                union all
+                union distinct
                 (select d.primary_kind, d.name, d.category, dck.kind as for_kind, dcv.code, dcv.factory from device_class d,
                  device_code_version dcv, device_class_kind dck where dck.device_id = d.id and
                  d.id = dcv.device_id and
                  ((dcv.version = d.developer_version and d.owner = ?) or
                   (dcv.version = d.approved_version and d.owner <> ?))
                  and dck.kind in (?))
-                union all
+                union distinct
                 (select d.primary_kind, d.name, d.category, dck2.kind as for_kind, dcv.code, dcv.factory from device_class d,
                  device_class d2, device_class_kind dck2, device_code_version dcv, device_class_kind dck
                  where dck.device_id = d.id and d.id = dcv.device_id and
@@ -487,13 +487,13 @@ module.exports = {
                  from device_class d, device_code_version dcv where d.id = dcv.device_id and
                  dcv.version = d.approved_version
                  and d.primary_kind in (?))
-                union all
+                union distinct
                 (select d.primary_kind, d.name, d.category, dck.kind as for_kind, dcv.code, dcv.factory from device_class d,
                  device_code_version dcv, device_class_kind dck where dck.device_id = d.id and
                  d.id = dcv.device_id and
                  dcv.version = d.approved_version
                  and dck.kind in (?))
-                union all
+                union distinct
                 (select d.primary_kind, d.name, d.category, dck2.kind as for_kind, dcv.code, dcv.factory from device_class d,
                  device_class d2, device_class_kind dck2, device_code_version dcv, device_class_kind dck
                  where dck.device_id = d.id and d.id = dcv.device_id and

--- a/tests/test_thingpedia_api_v3.js
+++ b/tests/test_thingpedia_api_v3.js
@@ -862,6 +862,7 @@ async function testGetDeviceSetup() {
         data: {
             'org.thingpedia.builtin.thingengine.builtin': {
                 type: 'multiple',
+                text: 'Miscellaneous Interfaces',
                 choices: []
             }
         }
@@ -878,6 +879,7 @@ async function testGetDeviceSetup() {
             },
             'org.thingpedia.builtin.thingengine.builtin': {
                 type: 'multiple',
+                text: 'Miscellaneous Interfaces',
                 choices: []
             }
         }
@@ -888,6 +890,7 @@ async function testGetDeviceSetup() {
         data: {
             'org.thingpedia.builtin.test.invisible': {
                 type: 'multiple',
+                text: 'org.thingpedia.builtin.test.invisible',
                 choices: []
             }
         }
@@ -925,6 +928,7 @@ async function testGetDeviceSetup() {
         data: {
             'org.thingpedia.builtin.test.adminonly': {
                 type: 'multiple',
+                text: 'org.thingpedia.builtin.test.adminonly',
                 choices: []
             }
         }

--- a/util/thingpedia-client.js
+++ b/util/thingpedia-client.js
@@ -258,6 +258,11 @@ module.exports = class ThingpediaClientCloud extends Tp.BaseClient {
             }
 
             const devices = await device.getDevicesForSetup(dbClient, kinds, org);
+            const names = {};
+            devices.forEach((d) => {
+                names[d.primary_kind] = d.name;
+            });
+
             const result = {};
             devices.forEach((d) => {
                 try {
@@ -266,7 +271,7 @@ module.exports = class ThingpediaClientCloud extends Tp.BaseClient {
                         if (d.for_kind in result) {
                             if (result[d.for_kind].type !== 'multiple') {
                                  let first_choice = result[d.for_kind];
-                                 result[d.for_kind] = { type: 'multiple', choices: [first_choice] };
+                                 result[d.for_kind] = { type: 'multiple', text: names[d.for_kind] || d.for_kind, choices: [first_choice] };
                             }
                             result[d.for_kind].choices.push(d.factory);
                         } else {
@@ -280,7 +285,7 @@ module.exports = class ThingpediaClientCloud extends Tp.BaseClient {
 
             for (let kind of kinds) {
                 if (!(kind in result))
-                    result[kind] = { type: 'multiple', choices: [] };
+                    result[kind] = { type: 'multiple', text: names[kind] || kind, choices: [] };
             }
 
             return result;


### PR DESCRIPTION
The class org.thingpedia.iot.switch can be configured in two ways:
- by configuring io.home-assistant, which can directly provide
  an org.thingpedia.iot.switch
- by configuring io.home-assistant, which can provide an
  org.thingpedia.iot.light-bulb, which is a kind of
  org.thingpedia.iot.switch

Indeed, this was visible because io.home-assistant was returned
in both branches of the SQL query. Using `union distinct` solves
the issue.

Additionally, we need to return the name of the device being configured
when we return multiple choices, or the client will be confused.