### PR TITLE
Wip/backend2

### DIFF
--- a/almond/control.js
+++ b/almond/control.js
@@ -1,0 +1,378 @@
+#!/usr/bin/env node
+// -*- mode: js; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of Almond
+//
+// Copyright 2017-2020 The Board of Trustees of the Leland Stanford Junior University
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
+"use strict";
+
+// load thingpedia to initialize the polyfill
+require('thingpedia');
+
+const express = require('express');
+const http = require('http');
+const url = require('url');
+const WebSocket = require('ws');
+const EngineManager = require('./enginemanager');
+const db = require('../util/db');
+const user = require('../model/user');
+const userToShardId = require('./shard');
+const bodyParser = require('body-parser');
+
+const stream = require('stream');
+const rpc = require('transparent-rpc');
+const argparse = require('argparse');
+
+const PlatformModule = require('./platform');
+const { JsonSocketAdapter } = require('../util/socket_utils');
+const i18n = require('../util/i18n');
+const Engine = require('./engine');
+
+
+class ControlServer {
+    constructor(port) {
+        this._sharedBackends = {};
+        this._app = express();
+        this._app.set('port', port)
+        this._app.use(bodyParser.json());
+        this._app.use(bodyParser.urlencoded({ extended: true }));
+
+        this._app.post('/registerBackend', (req, res, next) => {
+            Promise.resolve().then(async () => {
+                console.log(`---body: ${req.body}`);
+                console.log(`---body: ${JSON.stringify(req.body)}`);
+                res.json(this._registerBackend(req.body.backend));
+            }).catch(next);
+        });
+
+        this._app.get('/deregisterBackend', (req, res, next) => {
+            Promise.resolve().then(async () => {
+                res.json(this._deregisterBackend(res.body.backend));
+            }).catch(next);
+        });
+
+        this._app.get('/killAllUsers', (req, res, next) => {
+            Promise.resolve().then(async () => {
+                res.json(this._killAllUsers());
+            }).catch(next);
+        });
+
+        this._app.get('/engineUrl/:userId', (req, res, next) => {
+            Promise.resolve().then(async () => {
+               console.log(`engineUrl for userId: ${req.params.userId}`);
+               // const backend = this._sharedBackends[userToShardId(userId)];
+               const backend = this._sharedBackends[0];
+               res.json(backend.engineUrl);
+            }).catch(next);
+        });
+
+        this._app.get('/startUser/:userId', (req, res, next) => {
+            Promise.resolve().then(async () => {
+                res.json(this._startUser(req.params.userId));
+            }).catch(next);
+        });
+
+        this._app.get('/killUser/:userId', (req, res, next) => {
+            Promise.resolve().then(async () => {
+                res.json(this._killUser(req.params.userId));
+            }).catch(next);
+        });
+
+        this._server = http.createServer(this._app);
+    }
+
+    _registerBackend(backend) {
+        if (this._sharedBackends[backend.shardId]) {
+            console.log(`Backend ${backend.url} already connected`);
+            return;
+        }
+        const ws = new WebSocket(backend.url);
+        const jsonSocket = new JsonSocketAdapter(WebSocket.createWebSocketStream(ws));
+        const rpcSocket = new rpc.Socket(jsonSocket);
+        const connectedBackend = {
+            backend: null,
+            rpcSocket: rpcSocket,
+            expectClose: false,
+            url: backend.url,
+            engineUrl: backend.engineUrl,
+            shardId: backend.shardId
+        };
+        const ready = (msg) => {
+            if (msg.control === 'ready') {
+                jsonSocket.removeListener('data', ready);
+                console.log(`Channel to backend ${backend.url} ready`);
+                connectedBackend.backend = rpcSocket.getProxy(msg.rpcId);
+                this._sharedBackends[backend.shardId] = connectedBackend;
+                this._startBackend(connectedBackend);
+            }
+        };
+        jsonSocket.on('data', ready);
+        rpcSocket.on('close', () => {
+            console.log(`Channel to backend ${backend.url} closing`);
+            if (connectedBackend.expectClose)
+                return;
+            console.log(`Control channel to backend ${connectedBackend.url} severed`);
+            console.log('Reconnecting in 10s...');
+            setTimeout(() => {
+                this._registerBackend(backend);
+            }, 10000);
+        });
+        rpcSocket.on('error', () => {
+            // ignore the error, the socket will be closed soon and we'll deal with it
+        });
+    }
+
+    _deregisterBackend(backend) {
+        if (!this._sharedBackends[backend.shardId]) {
+            console.log(`Backend ${backend.url} already deregistered`);
+            return;
+        }
+        console.log(`Deregistering backend ${backend.url}`);
+        this._sharedBackends[backend.shardId].expecClose = true;
+        this._sharedBackends[backend.shardId].rpcSocket.end();
+        this._sharedBackends[backend.shardId] = null;
+    }
+     
+
+    async _getAllUsers(shardId) {
+        return db.withClient(async (client) => {
+            const rows = await user.getAllForShardId(client, shardId);
+            return Promise.all(rows.map((r) => {
+                // explicitly export user fields to worker nodes.
+                return {
+                    id: r.id,
+                    cloud_id: r.cloud_id,
+                    auth_token: r.auth_token,
+                    developer_key: r.developer_key,
+                    locale: r.locale,
+                    timezone: r.timezone,
+                    storage_key: r.storage_key,
+                    model_tag: r.model_tag
+                };
+            }));
+        });
+    }
+
+    async _getAllUsersTest(shardId) {
+       const rows = [
+           {
+               id: '0',
+               cloud_id: '100',
+               auth_token: 'auth-token',
+               developer_key: null,
+               locale: 'en-US',
+               timezone: null,
+               storage_key: null,
+               model_tag: null
+           },
+           {
+               id: '1',
+               cloud_id: '101',
+               auth_token: 'auth-token',
+               developer_key: null,
+               locale: 'en-US',
+               timezone: null,
+               storage_key: null,
+               model_tag: null
+           }
+       ]
+       return Promise.all(rows.map((r) => {
+           // explicitly export user fields to worker nodes.
+           return {
+               id: r.id,
+               cloud_id: r.cloud_id,
+               auth_token: r.auth_token,
+               developer_key: r.developer_key,
+               locale: r.locale,
+               timezone: r.timezone,
+               storage_key: r.storage_key,
+               model_tag: r.model_tag
+           };
+       }));
+    }
+
+    async _startBackend(connectedBackend) {
+        const users = await this._getAllUsersTest(connectedBackend.shardId);
+        console.log(`Starting backend ${connectedBackend.shardId} ${connectedBackend.url}`);
+        connectedBackend.backend.start(users);
+    }
+
+    async _killAllUsers() {
+        for (let shardId in this._sharedBackends) {
+            const backend = this._sharedBackends[shardId];
+            if (backend)
+                await backend.backend.killAllUsers();
+        }
+        return true;
+    }
+
+    _user(userId) {
+        return db.withClient((dbClient) => {
+            return user.get(dbClient, userId);
+        })
+    }
+
+    _userTest(userId) {
+        if (userId == '1')
+            return {
+                    id: '1',
+                    cloud_id: '101',
+                    auth_token: 'auth-token',
+                    developer_key: null,
+                    locale: 'en-US',
+                    timezone: null,
+                    storage_key: null,
+                    model_tag: null
+            };
+        if (userId == '3')
+            return {
+                    id: '3',
+                    cloud_id: '103',
+                    auth_token: 'auth-token',
+                    developer_key: null,
+                    locale: 'en-US',
+                    timezone: null,
+                    storage_key: null,
+                    model_tag: null
+            };
+        return {
+            id: '0',
+            cloud_id: '100',
+            auth_token: 'auth-token',
+            developer_key: null,
+            locale: 'en-US',
+            timezone: null,
+            storage_key: null,
+            model_tag: null
+         };
+    }
+
+    _backend(userId) {
+        // const backend = this._sharedBackends[userToShardId(userId)];
+        const backend = this._sharedBackends[0];
+        if (!backend) {
+            console.log("Warning: cannot find backendfor userId:" + userId);
+            return null;
+        }
+        return backend.backend;
+    }
+
+    async _startUser(userId) {
+        const backend = this._backend(userId);
+        if (!backend)
+            return false;
+        console.log(`===== starting user ${userId}`);
+        await backend.startUser(await this._userTest(userId));
+        return true;
+    }
+
+    async _killUser(userId) {
+        const backend = this._backend(userId);
+        if (!backend)
+            return false;
+        console.log(`===== kill user ${userId}`);
+        await backend.killUser(userId);
+        return true;
+    }
+
+    async start() {
+        // '::' means the same as 0.0.0.0 but for IPv6
+        // without it, node.js will only listen on IPv4
+        return new Promise((resolve, reject) => {
+            this._server.listen(this._app.get('port'), '::', (err) => {
+                if (err)
+                    reject(err);
+                else
+                    resolve();
+            });
+        }).then(() => {
+            console.log('Express server listening on port ' + this._app.get('port'));
+        });
+    }
+
+    stop() {
+        console.log('Stopping server');
+        for (let obj of this._engines.values()) {
+            console.log('Stopping engine of ' + obj.cloudId);
+            if (obj.running)
+                obj.engine.stop();
+
+            for (let sock of obj.sockets)
+                sock.end();
+        }
+
+        this._stopped = true;
+
+        // close the server asynchronously to avoid waiting on open
+        // connections
+        this._server.close((error) => {
+            if (error) {
+                console.log('Error stopping Express server: ' + error);
+                console.log(error.stack);
+            } else {
+                console.log('Express server stopped');
+            }
+        });
+        return Promise.resolve();
+    }
+}
+
+
+function main() {
+    const parser = new argparse.ArgumentParser({
+        add_help: true,
+        description: 'Almond backend control process'
+    });
+    parser.add_argument('-p', '--port', {
+        required: false,
+        type: Number,
+        help: 'Web server port',
+        default: 8080
+    });
+
+    const argv = parser.parse_args();
+
+    const controlServer = new ControlServer(argv.port);
+
+    let _stopping = false;
+    async function handleSignal() {
+        if (_stopping)
+            return;
+        _stopping = true;
+        try {
+            await masterServer.stop();
+        } catch(e) {
+            console.error('Failed to stop: ' + e.message);
+            console.error(e.stack);
+            process.exit(1);
+        }
+        process.exit(0);
+    }
+
+  
+    process.on('SIGINT', handleSignal);
+    process.on('SIGTERM', handleSignal);
+
+    controlServer.start().catch((e) => {
+        console.error('Failed to start: ' + e.message);
+        console.error(e.stack);
+        process.exit(1);
+    });
+
+}
+
+main();

--- a/almond/enginemanager.js
+++ b/almond/enginemanager.js
@@ -444,20 +444,6 @@ class EngineManager extends events.EventEmitter {
         }
     }
 
-    async sendWebSocket(userId, replyId, socket) {
-        if (this._engines[userId] === undefined)
-            throw new InternalError('E_INVALID_USER', 'Invalid user ID');
-        if (this._engines[userId].process === null)
-            throw new InternalError('E_ENGINE_DEAD', 'Engine dead');
-
-        const releaseLock = await this._lockUser(userId);
-        try {
-            this._engines[userId].process.send({ type: 'directws', target: userId, replyId: replyId }, socket);
-        } finally {
-            releaseLock();
-        }
-    }
-
     _startSharedProcesses(nprocesses) {
         let promises = new Array(nprocesses);
         this._rrproc = new Array(nprocesses);

--- a/almond/master.js
+++ b/almond/master.js
@@ -3,7 +3,7 @@
 //
 // This file is part of Almond
 //
-// Copyright 2017-2019 The Board of Trustees of the Leland Stanford Junior University
+// Copyright 2017-2020 The Board of Trustees of the Leland Stanford Junior University
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,72 +20,101 @@
 // Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
 "use strict";
 
-const assert = require('assert');
-const events = require('events');
-const rpc = require('transparent-rpc');
-const net = require('net');
-const sockaddr = require('sockaddr');
+// load thingpedia to initialize the polyfill
+require('thingpedia');
+
+const Tp = require('thingpedia');
 const os = require('os');
-
+const express = require('express');
+const http = require('http');
+const WebSocket = require('ws');
+const url = require('url');
+const net = require('net');
 const EngineManager = require('./enginemanager');
+
+const stream = require('stream');
+const rpc = require('transparent-rpc');
+const argparse = require('argparse');
+
+const PlatformModule = require('./platform');
 const JsonDatagramSocket = require('../util/json_datagram_socket');
-const { InternalError } = require('../util/errors');
+const { JsonSocketAdapter, SocketProxyServer } = require('../util/socket_utils');
+const i18n = require('../util/i18n');
+const Engine = require('./engine');
 
-const Config = require('../config');
-assert(Array.isArray(Config.THINGENGINE_MANAGER_ADDRESS));
 
-class ControlSocket extends events.EventEmitter {
-    constructor(engines, socket) {
-        super();
+class MasterServer {
+    constructor(options) {
+        this._options = options;
+        this._engines = new Map;
+        this._stopped = false;
+        const enginemanager = new EngineManager(options);
+        this._enginemanager = enginemanager;
+        this._proxySocketServer = new SocketProxyServer();
 
-        this._socket = socket;
-        const jsonSocket = new JsonDatagramSocket(socket, socket, 'utf8');
+	const masterServer = this;
 
-        this._authenticated = Config.THINGENGINE_MANAGER_AUTHENTICATION === null;
+        const backend_wss = new WebSocket.Server({ noServer: true });
+        this._backend_wss = backend_wss
+        backend_wss.on('connection', function connection(ws) {
+            console.log('---backend ws connection');
+            const jsonSocket = new JsonSocketAdapter(WebSocket.createWebSocketStream(ws));
+            const rpcSocket = new rpc.Socket(jsonSocket);
+            const id = rpcSocket.addStub(enginemanager);
+            jsonSocket.write({ control: 'ready', rpcId: id });
+        });
+
+
+        const engine_wss = new WebSocket.Server({ noServer: true });
+        this._engine_wss = engine_wss;
+        engine_wss.on('connection', async function connection(ws, request) {
+            console.log('connect engine request:' + request);
+            masterServer._connectEngine(ws);
+        });
+
+        this._app = express();
+        this._app.set('port', options.port)
+
+        this._server = http.createServer(this._app);
+        this._server.on('upgrade', function upgrade(request, socket, head) {
+          const pathname = url.parse(request.url).pathname;
+          if (pathname === '/backend') {
+              backend_wss.handleUpgrade(request, socket, head, function done(ws) {
+                  backend_wss.emit('connection', ws, request);
+              });
+          } else if (pathname === '/engine') {
+              engine_wss.handleUpgrade(request, socket, head, function done(ws) {
+                  engine_wss.emit('connection', ws, request);
+              });
+          } else {
+            console.log('Error http upgrade path: ' + pathname);
+            socket.destroy();
+          }
+        });
+    }
+
+
+    async _connectEngine(ws) {
+        console.log('connecting engine ...');
+        const socket = WebSocket.createWebSocketStream(ws);
+        const jsonSocket = new JsonDatagramSocket(socket, socket, 'utf-8');
+        const proxySocks = await this._proxySocketServer.newProxySocket(socket);
+        console.log('proxy socks created ...');
+        const enginemanager = this._enginemanager;
         const initListener = (msg) => {
-            if (msg.control === 'auth') {
-                if (msg.token === Config.THINGENGINE_MANAGER_AUTHENTICATION) {
-                    this._authenticated = true;
-                } else {
-                    this.emit('close');
-                    jsonSocket.write({ error: 'invalid authentication token' });
-                    jsonSocket.end();
-                    jsonSocket.removeListener('data', initListener);
-                }
-                return;
-            }
-            if (!this._authenticated) {
-                this.emit('close');
-                jsonSocket.write({ error: 'expected authentication' });
-                jsonSocket.end();
-                jsonSocket.removeListener('data', initListener);
-                return;
-            }
-
-            // ignore new-object messages that are sent during initialization
-            // of the rpc socket
+            console.log(`=== received msg: ${msg}`);
             if (msg.control === 'new-object')
                 return;
-
             jsonSocket.removeListener('data', initListener);
             if (msg.control === 'direct') {
-                socket.pause();
-                this.emit('close');
-                this._socket = null;
-                engines.sendSocket(msg.target, msg.replyId, socket).catch((e) => {
+                console.log(`=== sending socket to child`);
+                enginemanager.sendSocket(msg.target, msg.replyId, proxySocks.remoteSocket).catch((e) => {
+                    console.log(`=== sending socket to child err ${e.message}`);
                     jsonSocket.write({ error: e.message, code: e.code });
                     jsonSocket.end();
                 });
-            } else if (msg.control === 'master') {
-                this._rpcSocket = new rpc.Socket(jsonSocket);
-                this._rpcSocket.on('close', () => this.emit('close'));
-                this._rpcSocket.on('error', () => {
-                    // ignore the error, the connection will be closed soon
-                });
-
-                const id = this._rpcSocket.addStub(engines);
-                jsonSocket.write({ control: 'ready', rpcId: id });
             } else {
+                console.log(`=== sinvalid message`);
                 this.emit('close');
                 jsonSocket.write({ error: 'invalid initialization message' });
                 jsonSocket.end();
@@ -94,111 +123,156 @@ class ControlSocket extends events.EventEmitter {
         jsonSocket.on('data', initListener);
     }
 
-    end() {
-        this._socket.end();
-    }
-}
+    async start() {
+        this._proxySocketServer.start(); 
 
-class ControlSocketServer {
-    constructor(engines, shardId, k8s) {
-        this._server = net.createServer();
-        // In K8S, we assume the container port is the same as the service port
-        if (k8s)
-            this._address = sockaddr(`${process.env.HOSTNAME}:${process.env.ALMOND_BACKEND_SERVICE_PORT}`);
-        else
-            this._address = sockaddr(Config.THINGENGINE_MANAGER_ADDRESS[shardId]);
-        this._connections = new Set;
-        this._server.on('connection', (socket) => {
-            const control = new ControlSocket(engines, socket);
-            this._connections.add(control);
-            control.on('close', () => this._connections.delete(control));
-        });
-    }
-
-    start() {
+        // '::' means the same as 0.0.0.0 but for IPv6
+        // without it, node.js will only listen on IPv4
         return new Promise((resolve, reject) => {
-            this._server.listen(this._address, (err) => {
+            this._server.listen(this._app.get('port'), '::', (err) => {
                 if (err)
                     reject(err);
                 else
                     resolve();
             });
+        }).then(() => {
+            console.log('Express server listening on port ' + this._app.get('port'));
+            this._register();
+        });
+    }
+
+    _register() {
+        const backend = {
+            url: `ws://${this._options.hostname}:${this._options.port}/backend`,
+            engineUrl: `ws://${this._options.hostname}:${this._options.port}/engine`,
+            shardId: this._options.shard,
+        }
+        console.log(`Registering backend: ${backend.url} shardId: ${backend.shardId}`);
+        console.log(`POST ${this._options.control_url}/registerBackend  :` +  JSON.stringify({backend: backend}))
+        Tp.Helpers.Http.post(`${this._options.control_url}/registerBackend`, JSON.stringify({backend: backend}), {
+            dataContentType: 'application/json'
         });
     }
 
     stop() {
-        for (var conn of this._connections) {
-            try {
-                conn.end();
-            } catch(e) {
-                console.error(`Failed to stop one connection: ${e.message}`);
+        console.log('Stopping server');
+        for (let obj of this._engines.values()) {
+            console.log('Stopping engine of ' + obj.cloudId);
+            if (obj.running)
+                obj.engine.stop();
+
+            for (let sock of obj.sockets)
+                sock.end();
+        }
+
+        this._stopped = true;
+
+        // close the server asynchronously to avoid waiting on open
+        // connections
+        this._server.close((error) => {
+            if (error) {
+                console.log('Error stopping Express server: ' + error);
+                console.log(error.stack);
+            } else {
+                console.log('Express server stopped');
             }
-        }
-        this._server.close();
-    }
-}
-
-module.exports = {
-    initArgparse(subparsers) {
-        const parser = subparsers.add_parser('run-almond', {
-            description: 'Run the master Web Almond process'
         });
-        parser.add_argument('-s', '--shard', {
-            required: false,
-            type: Number,
-            help: 'Shard number for this process',
-            default: 0
-        });
-        parser.add_argument('--k8s', {
-            action: 'store_true',
-            default: false,
-            help: 'Enable running in kubernetes. The shard number will be inferred from the hostname.'
-        });
-    },
-
-    main(argv) {
-        if (argv.k8s) {
-            console.log(`Running in Kubernetes.`);
-            const hostname = os.hostname();
-            const match = /-([0-9]+)$/.exec(hostname);
-            argv.shard = parseInt(match[1], 10);
-            console.log(`Inferred hostname: ${hostname}, shard: ${argv.shard}`);
-        }
-
-        if (Number.isNaN(argv.shard) || argv.shard < 0 || argv.shard >= Config.THINGENGINE_MANAGER_ADDRESS.length)
-            throw new InternalError('E_INVALID_CONFIG', `Invalid shard number ${argv.shard}, must be between 0 and ${Config.THINGENGINE_MANAGER_ADDRESS.length-1}`);
-
-        const enginemanager = new EngineManager(argv.shard);
-
-        const controlSocket = new ControlSocketServer(enginemanager, argv.shard, argv.k8s);
-
-        controlSocket.start().then(() => {
-            return enginemanager.start();
-        }).catch((e) => {
-            console.error('Failed to start: ' + e.message);
-            console.error(e.stack);
-            process.exit(1);
-        });
-
-        let _stopping = false;
-        async function stop() {
-            if (_stopping)
-                return;
-            _stopping = true;
-            try {
-                await Promise.all([
-                    enginemanager.stop(),
-                    controlSocket.stop()
-                ]);
-            } catch(e) {
-                console.error('Failed to stop: ' + e.message);
-                console.error(e.stack);
-                process.exit(1);
-            }
-            process.exit(0);
-        }
-
-        process.on('SIGINT', stop);
-        process.on('SIGTERM', stop);
+        return Promise.resolve();
     }
 };
+
+MasterServer.prototype.$rpcMethods = ['runEngine', 'killEngine'];
+
+
+function main() {
+    const parser = new argparse.ArgumentParser({
+        add_help: true,
+        description: 'Worker Almond process'
+    });
+    parser.add_argument('--control-url', {
+        required: true,
+        help: 'Thingpedia URL',
+    });
+    parser.add_argument('-s', '--shard', {
+        required: false,
+        type: Number,
+        help: 'Shard number for this process',
+        default: 0
+    });
+    parser.add_argument('--k8s', {
+        action: 'store_true',
+        default: false,
+        help: 'Enable running in kubernetes. The shard number will be inferred from the hostname.'
+    });
+    parser.add_argument('--shared', {
+        action: 'store_true',
+        help: 'Run as a shared (multi-user) process',
+        default: false,
+    });
+    parser.add_argument('--supported-languages', {
+        action: 'append',
+        default: ['en-US'],
+        help: 'Supported languages',
+    });
+    parser.add_argument('--thingpedia-url', {
+        required: true,
+        help: 'Thingpedia URL',
+    });
+    parser.add_argument('--oauth-redirect-origin', {
+        required: true,
+        help: 'OAuth Redirect Origin',
+    });
+    parser.add_argument('--nl-server-url', {
+        required: true,
+        help: 'NLP Server URL',
+    });
+    parser.add_argument('--with-thingpedia', {
+        default: 'embedded',
+        help: 'Thingpedia mode',
+    });
+    parser.add_argument('-p', '--port', {
+        required: false,
+        type: Number,
+        help: 'Web server port',
+        default: 8081
+    });
+
+    const argv = parser.parse_args();
+    argv.hostname = os.hostname();
+    if (argv.k8s) {
+        console.log(`Running in Kubernetes.`);
+        const match = /-([0-9]+)$/.exec(argv.hostname);
+        argv.shard = parseInt(match[1], 10);
+        console.log(`Inferred hostname: ${hostname}, shardId: ${argv.shard}`);
+    }
+
+    const masterServer = new MasterServer(argv);
+
+    let _stopping = false;
+    async function handleSignal() {
+        if (_stopping)
+            return;
+        _stopping = true;
+        try {
+            await masterServer.stop();
+        } catch(e) {
+            console.error('Failed to stop: ' + e.message);
+            console.error(e.stack);
+            process.exit(1);
+        }
+        process.exit(0);
+    }
+
+  
+    process.on('SIGINT', handleSignal);
+    process.on('SIGTERM', handleSignal);
+
+    masterServer.start().catch((e) => {
+        console.error('Failed to start: ' + e.message);
+        console.error(e.stack);
+        process.exit(1);
+    });
+
+}
+
+main();

--- a/almond/master.js
+++ b/almond/master.js
@@ -3,7 +3,7 @@
 //
 // This file is part of Almond
 //
-// Copyright 2017-2020 The Board of Trustees of the Leland Stanford Junior University
+// Copyright 2017-2021 The Board of Trustees of the Leland Stanford Junior University
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/almond/run_master.sh
+++ b/almond/run_master.sh
@@ -1,16 +1,16 @@
 set -x
 
-# First run control.js first
+# First run control.js 
 #    node control.js
 
 
-# Second run master
-node master_server.js  \
+# Then run master
+node master.js  \
   --shared \
   --thingpedia-url /thingpedia \
   --nl-server-url https://nlp-staging.almond.stanford.edu \
   --oauth-redirect-origin https://dev.almond.stanford.edu \
   --control-url http://localhost:8080
 
-# Third test with test_client.js
+# Test with test_client.js
 #    node test_client.js

--- a/almond/run_master.sh
+++ b/almond/run_master.sh
@@ -1,0 +1,16 @@
+set -x
+
+# First run control.js first
+#    node control.js
+
+
+# Second run master
+node master_server.js  \
+  --shared \
+  --thingpedia-url /thingpedia \
+  --nl-server-url https://nlp-staging.almond.stanford.edu \
+  --oauth-redirect-origin https://dev.almond.stanford.edu \
+  --control-url http://localhost:8080
+
+# Third test with test_client.js
+#    node test_client.js

--- a/almond/test_client.js
+++ b/almond/test_client.js
@@ -3,16 +3,27 @@ const EngineManagerClient = require('./enginemanagerclient');
 
 async function main() {
     const client = new EngineManagerClient('http://localhost:8080');
-    // const resp = await client.startUser(3);
-    // const resp = await client.killUser('3');
-    // const resp = await client.killAllUsers();
-    const engine = await client.getEngine('3');
-    // const resp = await engine.getConsent();
-    let resp = await engine.recordingWarned();
-    console.log(`Response ${JSON.stringify(resp)}`);
-    resp = await engine.warnRecording();
-    console.log(`Response ${JSON.stringify(resp)}`);
-    resp = await engine.recordingWarned();
+    let resp = null;
+    resp = await client.startUser('3');
+    // resp = await client.isRunning('3');
+    // resp = await client.killUser('3');
+    // resp = await client.isRunning('3');
+    // resp = await client.startUser('3');
+    // resp = await client.isRunning('3');
+    // resp = await client.getProcessId('3');
+    // resp = await client.clearCache('3');
+    //  resp = await client.restartUser('3');
+    // resp = await client.deleteUser('3');
+    // resp = await client.restartUserWithoutCache('3');
+    // resp = await client.killAllUsers();
+
+    // resp = await client.startUser('3');
+    // const engine = await client.getEngine('3');
+    // resp = await engine.getConsent();
+    // resp = await engine.recordingWarned();
+    // resp = await engine.warnRecording();
+    // resp = await engine.recordingWarned();
+
     console.log(`Response ${JSON.stringify(resp)}`);
     client.stop();
 }

--- a/almond/test_client.js
+++ b/almond/test_client.js
@@ -1,0 +1,20 @@
+
+const EngineManagerClient = require('./enginemanagerclient');
+
+async function main() {
+    const client = new EngineManagerClient('http://localhost:8080');
+    // const resp = await client.startUser(3);
+    // const resp = await client.killUser('3');
+    // const resp = await client.killAllUsers();
+    const engine = await client.getEngine('3');
+    // const resp = await engine.getConsent();
+    let resp = await engine.recordingWarned();
+    console.log(`Response ${JSON.stringify(resp)}`);
+    resp = await engine.warnRecording();
+    console.log(`Response ${JSON.stringify(resp)}`);
+    resp = await engine.recordingWarned();
+    console.log(`Response ${JSON.stringify(resp)}`);
+    client.stop();
+}
+
+main();

--- a/almond/test_client.js
+++ b/almond/test_client.js
@@ -18,8 +18,8 @@ async function main() {
     // resp = await client.killAllUsers();
 
     // resp = await client.startUser('3');
-    // const engine = await client.getEngine('3');
-    // resp = await engine.getConsent();
+    const engine = await client.getEngine('3');
+    resp = await engine.getConsent();
     // resp = await engine.recordingWarned();
     // resp = await engine.warnRecording();
     // resp = await engine.recordingWarned();

--- a/almond/worker.js
+++ b/almond/worker.js
@@ -120,7 +120,7 @@ function handleDirectSocket(userId, replyId, socket) {
     let obj = _engines.get(userId);
     if (!obj) {
         console.log('Could not find an engine with the required user ID');
-        rpcSocket.call(replyId, 'error', ['---Invalid user ID ' + userId]);
+        rpcSocket.call(replyId, 'error', ['Invalid user ID ' + userId]);
         rpcSocket.end();
         return;
     }

--- a/almond/worker.js
+++ b/almond/worker.js
@@ -117,10 +117,6 @@ function handleDirectSocket(userId, replyId, socket) {
         console.log('Error on direct RPC socket: ' + e.message);
     });
 
-    for (let k in _engines) {
-       console.log(`child engine:${k} ${typeof(k)} ${typeof(userId)}`);
-    }
-    
     let obj = _engines.get(userId);
     if (!obj) {
         console.log('Could not find an engine with the required user ID');

--- a/almond/worker.js
+++ b/almond/worker.js
@@ -117,10 +117,14 @@ function handleDirectSocket(userId, replyId, socket) {
         console.log('Error on direct RPC socket: ' + e.message);
     });
 
+    for (let k in _engines) {
+       console.log(`child engine:${k} ${typeof(k)} ${typeof(userId)}`);
+    }
+    
     let obj = _engines.get(userId);
     if (!obj) {
         console.log('Could not find an engine with the required user ID');
-        rpcSocket.call(replyId, 'error', ['Invalid user ID ' + userId]);
+        rpcSocket.call(replyId, 'error', ['---Invalid user ID ' + userId]);
         rpcSocket.end();
         return;
     }


### PR DESCRIPTION
This PR is still work in progress but it's ready to get some feedbacks.  The main change is to separate out the controls in master to a separate server.  The control server also registers backends and provide discovery for clients.  This decouples the master from any DB, Config code and can run in an isolated environment.

 Another big change is replacing the backend socket with websockets.  However, it introduced complications with passing the socket to child. I agree  using domain sockets as proxy is a bit overkill but the advantage is the worker code untouched.  Since it is already working, I'll revisit this after coming back from vacation.

The code has been tested manually.  I've didn't take out the debug code and tests code.  Emily, you might want to take a look at these and consider making them into unit tests.  You can take a look at `run_master.sh`  There are still some TODOs  such as authentication, reconnect upon disconnect. 