### PR TITLE
Migrate preferences to SQL databases

### DIFF
--- a/go/sql/model.go
+++ b/go/sql/model.go
@@ -59,6 +59,7 @@ func init() {
 	registerRow(&UserApp{})
 	registerRow(&UserChannel{})
 	registerRow(&UserConversation{})
+	registerRow(&UserPreference{})
 
 	syncRows = make(map[string]SyncRow)
 	registerSyncRow(&UserDevice{})

--- a/go/sql/user_preference.go
+++ b/go/sql/user_preference.go
@@ -1,0 +1,50 @@
+// Copyright 2021 The Board of Trustees of the Leland Stanford Junior University
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package sql
+
+// UserPreference table
+type UserPreference struct {
+	Key
+	Value string `json:"value" gorm:"column:value"`
+}
+
+// TableName overrides table name to `user_preference`
+func (*UserPreference) TableName() string {
+	return "user_preference"
+}
+
+// NewRow returns a UserPreference row
+func (*UserPreference) NewRow() Row {
+	return &UserPreference{}
+}
+
+// NewRows returns a slice of UserPreference row
+func (*UserPreference) NewRows() interface{} {
+	return &[]*UserPreference{}
+}
+
+// SetKey sets the key of UserPreference
+func (e *UserPreference) SetKey(key Key) {
+	e.Key = key
+}
+
+// GetKey returns the key of UserPreference
+func (e *UserPreference) GetKey() Key {
+	return e.Key
+}
+
+// Fields returns column names excluding Key
+func (e *UserPreference) Fields() []string {
+	return []string{"value"}
+}

--- a/model/migrations/c84c8c2-user_preference.sql
+++ b/model/migrations/c84c8c2-user_preference.sql
@@ -1,0 +1,19 @@
+DROP TABLE IF EXISTS `user_preference`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `user_preference` (
+  `userId` int(11) not NULL,
+  `uniqueId` varchar(255) COLLATE utf8mb4_bin NOT NULL,
+  `value` text COLLATE utf8mb4_bin NOT NULL,
+  PRIMARY KEY (`userId`, `uniqueId`)
+)ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;

--- a/model/schema.sql
+++ b/model/schema.sql
@@ -1052,3 +1052,27 @@ CREATE TABLE `user_channel` (
 /*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+--
+-- Table structure for table `user_preference`
+--
+
+DROP TABLE IF EXISTS `user_preference`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `user_preference` (
+  `userId` int(11) not NULL,
+  `uniqueId` varchar(255) COLLATE utf8mb4_bin NOT NULL,
+  `value` text COLLATE utf8mb4_bin NOT NULL,
+  PRIMARY KEY (`userId`, `uniqueId`)
+)ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;

--- a/src/almond/preferences.ts
+++ b/src/almond/preferences.ts
@@ -1,0 +1,89 @@
+// -*- mode: typescript; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of Almond
+//
+// Copyright 2021 The Board of Trustees of the Leland Stanford Junior University
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
+
+import * as Tp from 'thingpedia';
+
+/**
+ * An implementation of the {@link Tp.Preferences} interface that
+ * interfaces with the DB proxy to store preferences in MySQL.
+ */
+export default class SQLPreferences extends Tp.Preferences {
+    private _baseUrl : string;
+    private _userId : number;
+    private _data : Record<string, unknown>;
+
+    constructor(baseUrl : string, userId : number) {
+        super();
+
+        this._baseUrl = baseUrl;
+        this._userId = userId;
+        this._data = {};
+    }
+
+    async init() {
+        // read all the preferences and cache them locally
+        // this allows clients to read the data synchronously,
+        // which the interface requires
+
+        const resp = await Tp.Helpers.Http.get(`${this._baseUrl}/localtable/user_preference/${this._userId}`);
+        const data = JSON.parse(resp)['data'];
+
+        for (const row of data)
+            this._data[row.uniqueId] = JSON.parse(data.value);
+    }
+
+    private _getObjectUrl(uniqueId : string) {
+        return `${this._baseUrl}/localtable/user_preference/${this._userId}/${encodeURIComponent(uniqueId)}`;
+    }
+
+    private async _flush(key : string) {
+        try {
+            if (this._data[key] === undefined) {
+                await Tp.Helpers.Http.request(this._getObjectUrl(key), 'DELETE', '');
+            } else {
+                // two layers of JSON.stringify: one is for HTTP transport and one is to put in the actual database
+                await Tp.Helpers.Http.post(this._getObjectUrl(key), JSON.stringify({ value: JSON.stringify(key) }), {
+                    dataContentType: 'applicatin/json'
+                });
+            }
+        } catch(e) {
+            console.error(`Failed to flush preference update to database: ${e.message}`);
+        }
+    }
+
+    get(key : string) : unknown {
+        return this._data[key];
+    }
+
+    set<T>(key : string, value : T) : T {
+        this._data[key] = value;
+        this._flush(key);
+        return value;
+    }
+
+    delete(key : string) {
+        delete this._data[key];
+        this._flush(key);
+    }
+
+    changed(key : string) {
+        this._flush(key);
+    }
+}


### PR DESCRIPTION
Genie engines currently store various user preferences in a JSON file called prefs.db in the engine working directory.
This doesn't work with Kubernetes, because there won't be a single persistent local disk when engines get migrated around. Instead, we should put the preferences in the MySQL DB like other pieces of user data.

The annoying part of this is that the preference interface is synchronous, so we need to load all the preferences during initialization, even though the interface is that of a key-value store.

We will also need a migration script to move the existing prefs.db files into SQL. @jgd5 can you repurpose your existing data migration script for this?
The format of prefs.db is a single JSON object, which is not quite the format that the existing migration script expects, from what i see (it seems to be JSON-L?).