### PR TITLE
Add support for PKCE in OAuth proxy

### DIFF
--- a/src/routes/devices.ts
+++ b/src/routes/devices.ts
@@ -94,8 +94,7 @@ router.get('/oauth2/:kind', (req, res, next) => {
         if (result !== null) {
             const redirect = result[0];
             const session = result[1];
-            for (const key in session)
-                req.session[key] = session[key];
+            req.session.oauth2 = session;
             res.redirect(303, redirect);
         } else {
             res.redirect(303, '/me');

--- a/src/routes/proxy.ts
+++ b/src/routes/proxy.ts
@@ -50,17 +50,15 @@ router.post('/oauth2', (req, res, next) => {
     user.getAnonymousUser(req.locale).then((new_user) => {
         EngineManager.get().getEngine(new_user.id).then(async (engine) => {
             const [redirect, session] = await engine.startOAuth(kind);
-            for (const key in session)
-                 req.session[key] = session[key];
+            req.session.proxyOAuth2 = session;
             res.redirect(303, redirect);
         }).catch((e) => {
             res.status(400).render('error', {
                 page_title: req._("Thingpedia - Error"),
                 message: e
             });
-        }).catch(next);
-    });
-
+        });
+    }).catch(next);
 });
 
 export default router;

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,11 +52,15 @@ declare module 'express-session' {
         // redirect after configuring a device
         'device-redirect-to' : string;
 
+        // OAuth session data
+        oauth2 : Record<string, string>;
+        proxyOAuth2 : Record<string, string>;
+
         // redirect for OAuth proxy
         redirect : string;
         kind : string;
 
-        [key : string] : unknown;
+        //[key : string] : unknown;
     }
 }
 

--- a/tests/website/test_oauth_proxy.js
+++ b/tests/website/test_oauth_proxy.js
@@ -30,14 +30,16 @@ async function testWithoutQueryString(session) {
 
     assert(response.includes(`<h2>OAuth request for: </h2><span> </span><h3>com.spotify</h3><span> </span><h2>from: </h2><h3>localhost:1234</h3>`));
 
-    assertRedirect(sessionRequest('/proxy/oauth2', 'POST', { device_type: 'com.spotify' }, session, { followRedirects: false }), (redirect) => {
+    await assertRedirect(sessionRequest('/proxy/oauth2', 'POST', { device_type: 'com.spotify' }, session, { followRedirects: false }), (redirect) => {
         assert(redirect.startsWith('https://accounts.spotify.com/authorize'));
     });
 
-    assertRedirect(sessionRequest('/devices/oauth2/callback/com.spotify', 'GET', {
+    await assertRedirect(sessionRequest('/devices/oauth2/callback/com.spotify', 'GET', {
         authorization_code: 'code-123456',
         state: 'abcdef'
-    }, session, { followRedirects: false }), 'http://localhost:1234/subpath/devices/oauth2/callback/com.spotify?authorization_code=code-123456&state=abcdef');
+    }, session, { followRedirects: false }), (redirect) => {
+        assert(redirect.startsWith('http://localhost:1234/subpath/devices/oauth2/callback/com.spotify?authorization_code=code-123456&state=abcdef&proxy_session%5Boauth2-pkce-com.spotify%5D='), `Invalid redirect ${redirect}`);
+    });
 }
 
 async function testWithQueryString(session) {
@@ -48,14 +50,16 @@ async function testWithQueryString(session) {
 
     assert(response.includes(`<h2>OAuth request for: </h2><span> </span><h3>com.spotify</h3><span> </span><h2>from: </h2><h3>localhost:1235</h3>`));
 
-    assertRedirect(sessionRequest('/proxy/oauth2', 'POST', { device_type: 'com.spotify' }, session, { followRedirects: false }), (redirect) => {
+    await assertRedirect(sessionRequest('/proxy/oauth2', 'POST', { device_type: 'com.spotify' }, session, { followRedirects: false }), (redirect) => {
         assert(redirect.startsWith('https://accounts.spotify.com/authorize'));
     });
 
-    assertRedirect(sessionRequest('/devices/oauth2/callback/com.spotify', 'GET', {
+    await assertRedirect(sessionRequest('/devices/oauth2/callback/com.spotify', 'GET', {
         authorization_code: 'code-123457',
         state: 'abcdef'
-    }, session, { followRedirects: false }), 'http://localhost:1235/subpath?foo=1&bar=2&authorization_code=code-123457&state=abcdef');
+    }, session, { followRedirects: false }), (redirect) => {
+        assert(redirect.startsWith('http://localhost:1235/subpath?foo=1&bar=2&authorization_code=code-123457&state=abcdef&proxy_session%5Boauth2-pkce-com.spotify%5D='), `Invalid redirect ${redirect}`);
+    });
 }
 
 async function main() {


### PR DESCRIPTION
To support PKCE, we need to forward the session state to almond-server,
which then contacts the third-party service to get the session token.

The session format is changed to keep oauth2 session information
separate from other session data, and avoid accidental leaks.

@ryachen01 this is the cloud side to support PKCE, you can implement the almond-server side if you want.
Otherwise I'll get to it after this one is merged and deployed.