### PR TITLE
go/sql: fix types of user fields and platform options

### DIFF
--- a/go/k8s/controllers/user_controller.go
+++ b/go/k8s/controllers/user_controller.go
@@ -56,19 +56,19 @@ const (
 
 // PlatformOptions is part of runEngine request
 type PlatformOptions struct {
-	UserID             int64  `json:"userId"`
-	CloudID            string `json:"cloudId"`
-	AuthToken          string `json:"authToken"`
-	DeveloperKey       string `json:"developerKey"`
-	Locale             string `json:"locale"`
-	Timezone           string `json:"timezone"`
-	DBProxyURL         string `json:"dbProxyUrl"`
-	DBProxyAccessToken string `json:"dbProxyAccessToken"`
-	HumanName          string `json:"humanName"`
-	Email              string `json:"email"`
+	UserID             int64   `json:"userId"`
+	CloudID            string  `json:"cloudId"`
+	AuthToken          string  `json:"authToken"`
+	DeveloperKey       *string `json:"developerKey"`
+	Locale             string  `json:"locale"`
+	Timezone           string  `json:"timezone"`
+	DBProxyURL         string  `json:"dbProxyUrl"`
+	DBProxyAccessToken string  `json:"dbProxyAccessToken"`
+	HumanName          *string `json:"humanName"`
+	Email              *string `json:"email"`
 }
 
-func platformOptions(user *sql.User, developerKey string, dbProxyURL string, dbProxyToken string) *PlatformOptions {
+func platformOptions(user *sql.User, developerKey *string, dbProxyURL string, dbProxyToken string) *PlatformOptions {
 	return &PlatformOptions{
 		UserID:             user.ID,
 		CloudID:            user.CloudID,

--- a/go/sql/users.go
+++ b/go/sql/users.go
@@ -23,25 +23,25 @@ import (
 type User struct {
 	ID                  int64     `json:"id"                      gorm:"column:id"`
 	Username            string    `json:"username"                gorm:"column:username"`
-	HumanName           string    `json:"human_name"              gorm:"column:human_name"`
-	Email               string    `json:"email"                   gorm:"column:email"`
-	EmailVerified       string    `json:"email_verified"          gorm:"column:email_verified"`
-	Phone               string    `json:"phone"                   gorm:"column:phone"`
+	HumanName           *string   `json:"human_name"              gorm:"column:human_name"`
+	Email               *string   `json:"email"                   gorm:"column:email"`
+	EmailVerified       bool      `json:"email_verified"          gorm:"column:email_verified"`
+	Phone               *string   `json:"phone"                   gorm:"column:phone"`
 	Locale              string    `json:"locale"                  gorm:"column:locale"`
 	Timezone            string    `json:"timezone"                gorm:"column:timezone"`
-	ModelTag            string    `json:"model_tag"               gorm:"column:model_tag"`
-	GoogleID            string    `json:"google_id"               gorm:"column:google_id"`
-	GithubID            string    `json:"github_id"               gorm:"column:github_id"`
-	FacebookID          string    `json:"facebook_id"             gorm:"column:facebook_id"`
-	OmletI              string    `json:"omlet_id"                gorm:"column:omlet_id"`
-	Password            string    `json:"password"                gorm:"column:password"`
-	Salt                string    `json:"salt"                    gorm:"column:salt"`
-	TotpKey             string    `json:"totp_key"                gorm:"column:totp_key"`
+	ModelTag            *string   `json:"model_tag"               gorm:"column:model_tag"`
+	GoogleID            *string   `json:"google_id"               gorm:"column:google_id"`
+	GithubID            *string   `json:"github_id"               gorm:"column:github_id"`
+	FacebookID          *string   `json:"facebook_id"             gorm:"column:facebook_id"`
+	OmletID             *string   `json:"omlet_id"                gorm:"column:omlet_id"`
+	Password            *string   `json:"password"                gorm:"column:password"`
+	Salt                *string   `json:"salt"                    gorm:"column:salt"`
+	TotpKey             *string   `json:"totp_key"                gorm:"column:totp_key"`
 	CloudID             string    `json:"cloud_id"                gorm:"column:cloud_id"`
 	AuthToken           string    `json:"auth_token"              gorm:"column:auth_token"`
 	StorageKey          string    `json:"storage_key"             gorm:"column:storage_key"`
 	Roles               int       `json:"roles"                   gorm:"column:roles"`
-	AssistantFeedId     string    `json:"assistant_feed_id"       gorm:"column:assistant_feed_id"`
+	AssistantFeedId     *string   `json:"assistant_feed_id"       gorm:"column:assistant_feed_id"`
 	DeveloperStatus     int       `json:"developer_status"        gorm:"column:developer_status"`
 	DeveloperOrg        int       `json:"developer_org"           gorm:"column:developer_org"`
 	ForceSparateProcess int       `json:"force_separate_process"  gorm:"column:force_separate_process"`
@@ -62,9 +62,9 @@ func GetUser(db *gorm.DB, uid int64) (*User, error) {
 }
 
 // GetDeveloperKey returns the developer key of a given user id from database
-func GetDeveloperKey(db *gorm.DB, uid int64) (string, error) {
+func GetDeveloperKey(db *gorm.DB, uid int64) (*string, error) {
 	row := struct {
-		DeveloperKey string `gorm:"column:developer_key"`
+		DeveloperKey *string `gorm:"column:developer_key"`
 	}{}
 	result := db.Raw("select o.developer_key"+
 		" from users u left outer join organizations o on u.developer_org = o.id"+


### PR DESCRIPTION
Nullable fields need to be pointers, otherwise null will turn into an empty string which is not correct.

---

This should fix some weird issues in the Genie engine tests during cloud sync, caused by the test user having an empty developer key (instead of the expected null)