### PR TITLE
Fix cloud sync discriminator handling

### DIFF
--- a/go/sql/sync_table_test.go
+++ b/go/sql/sync_table_test.go
@@ -62,13 +62,16 @@ func (s *SyncTableSuite) SetupSuite() {
 
 	require.NoError(s.T(), err)
 	s.syncTable = NewSyncTable(s.DB)
+
+	s1 := "state1"
+	s2 := "state2"
 	s.row1 = &UserDevice{
 		Key:   Key{UniqueID: "u1", UserID: 1},
-		State: "state1",
+		State: &s1,
 	}
 	s.row2 = &UserDevice{
 		Key:   Key{UniqueID: "u2", UserID: 1},
-		State: "state2",
+		State: &s2,
 	}
 	s.record1 = &UserDeviceSyncRecord{
 		State: s.row1.State,

--- a/go/sql/user_device.go
+++ b/go/sql/user_device.go
@@ -16,7 +16,7 @@ package sql
 // UserDevice table
 type UserDevice struct {
 	Key
-	State string `json:"state" gorm:"column:state"`
+	State *string `json:"state" gorm:"column:state"`
 }
 
 // TableName overrides table name to `user_device`
@@ -104,7 +104,7 @@ func (e *UserDeviceJournal) Fields() []string {
 // UserDeviceSyncRecord is the joined row of UserDevice and UserDeviceJournal
 type UserDeviceSyncRecord struct {
 	UserDeviceJournal
-	State string `json:"state" gorm:"column:state"`
+	State *string `json:"state" gorm:"column:state"`
 }
 
 // Row
@@ -132,5 +132,5 @@ func (r *UserDeviceSyncRecord) SetLastModified(t int64) {
 
 // HasDiscriminator
 func (r *UserDeviceSyncRecord) HasDiscriminator() bool {
-	return len(r.State) > 0
+	return r.State != nil && len(*r.State) > 0
 }


### PR DESCRIPTION
In the sync record, all fields must be nullable, because they will
be null when retrieving a deletion record. If the fields are not
nullable, null in SQL becomes empty string on the wire, which
is not valid and confuses the cloud sync client.