### PR TITLE
K8s-backend: fix shared cache dir

### DIFF
--- a/src/almond/platform.ts
+++ b/src/almond/platform.ts
@@ -222,7 +222,7 @@ export class Platform extends Tp.BasePlatform {
 
         this._writabledir = _shared ? (process.cwd() + '/' + options.cloudId) : process.cwd();
         try {
-            fs.mkdirSync(this._writabledir + '/cache');
+            fs.mkdirSync(this._writabledir + '/cache', {recursive: true});
         } catch(e) {
             if (e.code !== 'EEXIST')
                 throw e;

--- a/tests/thingpedia-integration/k8s/shared-backend.yaml
+++ b/tests/thingpedia-integration/k8s/shared-backend.yaml
@@ -31,6 +31,7 @@ spec:
                 --faq-models={} \
                 --notification-config={} \
                 --locale=en-US \
+                --shared \
                 --activity-monitor-idle-timeout-millis=10000 \
                 --activity-monitor-quiesce-timeout-millis=1000 \
                 &


### PR DESCRIPTION
This PR allows k8s-backend to use shared worker, which is a temp fix for #1087 